### PR TITLE
feat(fixtures): add pytest-like fixture system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Fixture system with pytest-like `conftest.do` pattern
+- Built-in fixtures:
+  - `use_fixture` - Request a fixture by name
+  - `fixture_tempfile` - Temporary file path
+  - `fixture_empty_dataset` - Empty dataset with optional observation count
+  - `fixture_seed` - Reproducible random seed
+- Fixture scoping: function, module, session
+- Automatic `conftest.do` discovery in directory hierarchy
+- Fixture example in `examples/fixtures/`
+- Python tests for fixture module (8 new tests)
+
+### Changed
+
+- Reorganized package structure: moved ado files to `statatest/ado/`
+- Improved path handling with `importlib.resources`
+
 ## [0.1.0] - 2025-12-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,6 +80,48 @@ end
 | `assert_var_exists` | Variable exists | `assert_var_exists myvar` |
 | `assert_approx_equal` | Float comparison | `assert_approx_equal r(mean), expected(0.5) tol(0.01)` |
 
+## Fixtures
+
+Create reusable setup/teardown functions with `conftest.do`:
+
+```stata
+// tests/conftest.do - Shared fixtures
+
+program define fixture_sample_panel
+    clear
+    set obs 100
+    gen int firm_id = ceil(_n / 10)
+    gen int year = 2010 + mod(_n, 10)
+    gen double revenue = exp(rnormal(15, 2))
+end
+
+program define fixture_sample_panel_teardown
+    clear
+end
+```
+
+Use fixtures in your tests:
+
+```stata
+// tests/test_analysis.do
+// @uses_fixture: sample_panel
+
+program define test_panel_analysis
+    use_fixture sample_panel
+
+    assert_obs_count 100
+    assert_var_exists revenue
+end
+```
+
+Built-in fixtures:
+
+| Fixture | Purpose |
+|---------|---------|
+| `fixture_tempfile` | Temporary file path (`$fixture_tempfile_path`) |
+| `fixture_empty_dataset` | Empty dataset with optional obs count |
+| `fixture_seed` | Reproducible random seed |
+
 ## Configuration
 
 Create `statatest.toml` in your project root:

--- a/examples/fixtures/conftest.do
+++ b/examples/fixtures/conftest.do
@@ -1,0 +1,34 @@
+// conftest.do - Shared fixtures for test examples
+//
+// This file defines fixtures that can be used across multiple tests.
+// Fixtures are loaded automatically before tests run.
+
+// Custom fixture: Creates a sample panel dataset
+program define fixture_sample_panel
+    syntax [, scope(string)]
+
+    clear
+    set obs 100
+
+    // Generate panel structure
+    gen int firm_id = ceil(_n / 10)
+    bysort firm_id: gen int year = 2010 + _n - 1
+
+    // Generate variables
+    gen double revenue = exp(rnormal(15, 2))
+    gen double employees = exp(rnormal(3, 1))
+    gen double capital = exp(rnormal(10, 2))
+
+    // Label variables
+    label variable firm_id "Firm identifier"
+    label variable year "Year"
+    label variable revenue "Revenue (nominal)"
+    label variable employees "Number of employees"
+    label variable capital "Capital stock"
+end
+
+program define fixture_sample_panel_teardown
+    clear
+    capture scalar drop _FIXTURE_sample_panel
+    noisily display "_STATATEST_FIXTURE_:teardown_:sample_panel_END_"
+end

--- a/examples/fixtures/test_with_fixtures.do
+++ b/examples/fixtures/test_with_fixtures.do
@@ -1,0 +1,74 @@
+// test_with_fixtures.do - Example test using fixtures
+//
+// Run with: statatest examples/fixtures/
+//
+// @marker: unit
+// @uses_fixture: sample_panel
+
+clear all
+
+// Test 1: Sample panel has expected structure
+program define test_panel_structure
+    // Load the fixture
+    use_fixture sample_panel
+
+    // Check observations
+    assert_obs_count 100
+
+    // Check variables exist
+    assert_var_exists firm_id
+    assert_var_exists year
+    assert_var_exists revenue
+    assert_var_exists employees
+    assert_var_exists capital
+end
+
+// Test 2: Panel has 10 firms
+program define test_firm_count
+    use_fixture sample_panel
+
+    // Count unique firms
+    quietly distinct firm_id
+    assert_equal "`r(ndistinct)'", expected("10") message("Should have 10 firms")
+end
+
+// Test 3: Each firm has 10 years
+program define test_years_per_firm
+    use_fixture sample_panel
+
+    // Check balanced panel
+    bysort firm_id: gen n_years = _N
+    assert_true n_years[1] == 10
+end
+
+// Test 4: Variables are positive
+program define test_positive_values
+    use_fixture sample_panel
+
+    // All values should be positive
+    assert_true revenue > 0
+    assert_true employees > 0
+    assert_true capital > 0
+end
+
+// Test 5: Use built-in seed fixture for reproducibility
+program define test_with_seed
+    // Use seed fixture for reproducible random numbers
+    fixture_seed, seed(42)
+
+    clear
+    set obs 10
+    gen x = rnormal()
+
+    // First value should be consistent with seed 42
+    assert_true _N == 10
+end
+
+// Run all tests
+test_panel_structure
+test_firm_count
+test_years_per_firm
+test_positive_values
+test_with_seed
+
+display "All fixture tests passed!"

--- a/src/statatest/ado/fixtures/fixture_empty_dataset.ado
+++ b/src/statatest/ado/fixtures/fixture_empty_dataset.ado
@@ -1,0 +1,41 @@
+*! fixture_empty_dataset v1.0.0  statatest  2025-12-26
+*! Author: Jose Ignacio Gonzalez Rojas
+*!
+*! Built-in fixture: Creates an empty dataset with specified observations.
+*!
+*! Syntax:
+*!   fixture_empty_dataset [, scope(string) obs(integer)]
+*!
+*! Example:
+*!   use_fixture empty_dataset
+*!   // Now have empty dataset with 0 observations
+*!
+*!   fixture_empty_dataset, obs(100)
+*!   // Now have empty dataset with 100 observations
+
+program define fixture_empty_dataset, rclass
+    version 16
+
+    syntax [, Scope(string) OBS(integer 0)]
+
+    // Clear current data
+    clear
+
+    // Set observations if specified
+    if `obs' > 0 {
+        quietly set obs `obs'
+    }
+
+    return local obs "`obs'"
+end
+
+program define fixture_empty_dataset_teardown
+    // Clear data
+    clear
+
+    // Clear fixture marker
+    capture scalar drop _FIXTURE_empty_dataset
+
+    // Emit marker
+    noisily display "_STATATEST_FIXTURE_:teardown_:empty_dataset_END_"
+end

--- a/src/statatest/ado/fixtures/fixture_seed.ado
+++ b/src/statatest/ado/fixtures/fixture_seed.ado
@@ -1,0 +1,45 @@
+*! fixture_seed v1.0.0  statatest  2025-12-26
+*! Author: Jose Ignacio Gonzalez Rojas
+*!
+*! Built-in fixture: Sets a reproducible random seed.
+*!
+*! Syntax:
+*!   fixture_seed [, scope(string) seed(integer)]
+*!
+*! Example:
+*!   use_fixture seed
+*!   // Now have reproducible seed (default: 12345)
+*!
+*!   fixture_seed, seed(42)
+*!   // Now have seed set to 42
+
+program define fixture_seed, rclass
+    version 16
+
+    syntax [, Scope(string) SEED(integer 12345)]
+
+    // Store original seed state for restoration
+    local original_seed = c(rngstate)
+    global _FIXTURE_seed_original "`original_seed'"
+
+    // Set reproducible seed
+    set seed `seed'
+
+    return local seed "`seed'"
+end
+
+program define fixture_seed_teardown
+    // Restore original seed state if stored
+    if "$_FIXTURE_seed_original" != "" {
+        set rngstate $_FIXTURE_seed_original
+    }
+
+    // Clear globals
+    global _FIXTURE_seed_original
+
+    // Clear fixture marker
+    capture scalar drop _FIXTURE_seed
+
+    // Emit marker
+    noisily display "_STATATEST_FIXTURE_:teardown_:seed_END_"
+end

--- a/src/statatest/ado/fixtures/fixture_tempfile.ado
+++ b/src/statatest/ado/fixtures/fixture_tempfile.ado
@@ -1,0 +1,56 @@
+*! fixture_tempfile v1.0.0  statatest  2025-12-26
+*! Author: Jose Ignacio Gonzalez Rojas
+*!
+*! Built-in fixture: Creates a temporary file path.
+*!
+*! After calling this fixture, the global $fixture_tempfile_path
+*! contains the path to a temporary file that will be cleaned up
+*! after the test.
+*!
+*! Syntax:
+*!   fixture_tempfile [, scope(string) suffix(string)]
+*!
+*! Example:
+*!   use_fixture tempfile
+*!   save "$fixture_tempfile_path", replace
+
+program define fixture_tempfile, rclass
+    version 16
+
+    syntax [, Scope(string) SUFfix(string)]
+
+    // Default suffix is .dta
+    if `"`suffix'"' == "" {
+        local suffix ".dta"
+    }
+
+    // Generate temporary file path
+    tempfile tmpfile
+    local filepath "`tmpfile'`suffix'"
+
+    // Store in global for access
+    global fixture_tempfile_path "`filepath'"
+
+    // Store for cleanup tracking
+    global _FIXTURE_tempfile_cleanup "`filepath'"
+
+    return local path "`filepath'"
+end
+
+program define fixture_tempfile_teardown
+    // Clean up temporary file if it exists
+    capture confirm file "$_FIXTURE_tempfile_cleanup"
+    if _rc == 0 {
+        erase "$_FIXTURE_tempfile_cleanup"
+    }
+
+    // Clear globals
+    global fixture_tempfile_path
+    global _FIXTURE_tempfile_cleanup
+
+    // Clear fixture marker
+    capture scalar drop _FIXTURE_tempfile
+
+    // Emit marker
+    noisily display "_STATATEST_FIXTURE_:teardown_:tempfile_END_"
+end

--- a/src/statatest/ado/fixtures/use_fixture.ado
+++ b/src/statatest/ado/fixtures/use_fixture.ado
@@ -1,0 +1,67 @@
+*! use_fixture v1.0.0  statatest  2025-12-26
+*! Author: Jose Ignacio Gonzalez Rojas
+*!
+*! Request a fixture by name, invoking setup if needed.
+*!
+*! Syntax:
+*!   use_fixture name [, scope(string)]
+*!
+*! Scopes:
+*!   - function (default): Setup/teardown per test function
+*!   - module: Setup once per test file, teardown at end
+*!   - session: Setup once per test run, teardown at end
+*!
+*! Example:
+*!   use_fixture sample_panel
+*!   use_fixture empty_dataset, scope(function)
+
+program define use_fixture, rclass
+    version 16
+
+    syntax anything(name=fixture_name), [Scope(string)]
+
+    // Default scope is function
+    if `"`scope'"' == "" {
+        local scope "function"
+    }
+
+    // Validate scope
+    if !inlist(`"`scope'"', "function", "module", "session") {
+        display as error "Invalid scope: `scope'"
+        display as error "  Valid scopes: function, module, session"
+        exit 198
+    }
+
+    // Check if fixture is already active (for module/session scopes)
+    local fixture_var "_FIXTURE_`fixture_name'"
+    capture confirm scalar `fixture_var'
+    if _rc == 0 {
+        // Fixture already active, skip setup
+        return local fixture_name "`fixture_name'"
+        return local scope "`scope'"
+        return local already_active "1"
+        exit
+    }
+
+    // Look for fixture setup program
+    local setup_prog "fixture_`fixture_name'"
+    capture which `setup_prog'
+    if _rc != 0 {
+        display as error "Fixture not found: `fixture_name'"
+        display as error "  Expected program: `setup_prog'"
+        exit 111
+    }
+
+    // Run fixture setup
+    `setup_prog', scope(`scope')
+
+    // Mark fixture as active
+    scalar `fixture_var' = 1
+
+    // Emit marker for test runner
+    noisily display "_STATATEST_FIXTURE_:setup_:`fixture_name'_END_"
+
+    return local fixture_name "`fixture_name'"
+    return local scope "`scope'"
+    return local already_active "0"
+end

--- a/src/statatest/fixtures.py
+++ b/src/statatest/fixtures.py
@@ -1,0 +1,177 @@
+"""Fixture system for statatest - pytest-like fixtures for Stata tests."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from statatest.models import TestFile
+
+
+@dataclass(slots=True)
+class Fixture:
+    """Represents a fixture definition."""
+
+    name: str
+    scope: str = "function"  # function, module, session
+    setup_program: str = ""
+    teardown_program: str = ""
+    source_file: Path | None = None
+
+
+@dataclass(slots=True)
+class FixtureManager:
+    """Manages fixture lifecycle across test runs."""
+
+    fixtures: dict[str, Fixture] = field(default_factory=dict)
+    active_fixtures: dict[str, str] = field(default_factory=dict)  # name -> scope
+
+    def register_fixture(self, fixture: Fixture) -> None:
+        """Register a fixture definition."""
+        self.fixtures[fixture.name] = fixture
+
+    def get_fixture(self, name: str) -> Fixture | None:
+        """Get a fixture by name."""
+        return self.fixtures.get(name)
+
+    def is_active(self, name: str) -> bool:
+        """Check if a fixture is currently active."""
+        return name in self.active_fixtures
+
+    def activate(self, name: str, scope: str) -> None:
+        """Mark a fixture as active."""
+        self.active_fixtures[name] = scope
+
+    def deactivate(self, name: str) -> None:
+        """Mark a fixture as inactive."""
+        self.active_fixtures.pop(name, None)
+
+    def get_teardown_list(self, scope: str) -> list[str]:
+        """Get list of fixtures to teardown for a given scope.
+
+        Args:
+            scope: The scope level (function, module, session)
+
+        Returns:
+            List of fixture names to teardown
+        """
+        return [
+            name
+            for name, fixture_scope in self.active_fixtures.items()
+            if fixture_scope == scope
+        ]
+
+
+def discover_conftest(test_dir: Path) -> list[Path]:
+    """Find all conftest.do files in directory hierarchy.
+
+    Searches from test_dir up to the root, collecting conftest.do files.
+    Files closer to the test take precedence (loaded last).
+
+    Args:
+        test_dir: Directory containing tests
+
+    Returns:
+        List of conftest.do paths, from root to test_dir
+    """
+    conftest_files: list[Path] = []
+
+    # Walk up from test_dir to root
+    current = test_dir.resolve()
+    while current != current.parent:
+        conftest = current / "conftest.do"
+        if conftest.exists():
+            conftest_files.append(conftest)
+        current = current.parent
+
+    # Reverse so root comes first (will be loaded first)
+    conftest_files.reverse()
+    return conftest_files
+
+
+def parse_conftest(conftest_path: Path) -> list[Fixture]:
+    """Parse a conftest.do file to extract fixture definitions.
+
+    Looks for programs named fixture_* (but not fixture_*_teardown).
+
+    Args:
+        conftest_path: Path to conftest.do file
+
+    Returns:
+        List of Fixture objects found
+    """
+    content = conftest_path.read_text(encoding="utf-8")
+
+    # Find all fixture_* programs
+    fixture_pattern = re.compile(
+        r"program\s+define\s+fixture_(\w+)",
+        re.IGNORECASE | re.MULTILINE,
+    )
+
+    # Collect all fixture names (including teardown)
+    all_names: list[str] = []
+    for match in fixture_pattern.finditer(content):
+        all_names.append(match.group(1))
+
+    # Filter out teardown programs and create fixtures
+    fixtures: list[Fixture] = []
+    for name in all_names:
+        # Skip if this is a teardown program
+        if name.endswith("_teardown"):
+            continue
+
+        setup_prog = f"fixture_{name}"
+        teardown_prog = f"fixture_{name}_teardown"
+
+        # Check if teardown exists
+        has_teardown = f"{name}_teardown" in all_names
+
+        fixtures.append(
+            Fixture(
+                name=name,
+                setup_program=setup_prog,
+                teardown_program=teardown_prog if has_teardown else "",
+                source_file=conftest_path,
+            )
+        )
+
+    return fixtures
+
+
+def get_test_fixtures(test: TestFile) -> list[str]:
+    """Extract fixture requirements from a test file.
+
+    Looks for @uses_fixture comments or use_fixture calls.
+
+    Args:
+        test: TestFile to analyze
+
+    Returns:
+        List of fixture names required by the test
+    """
+    content = test.path.read_text(encoding="utf-8")
+
+    fixtures: set[str] = set()
+
+    # Pattern: // @uses_fixture: name or // @uses_fixture: name1, name2
+    comment_pattern = re.compile(
+        r"//\s*@uses_fixture:\s*(\w+(?:\s*,\s*\w+)*)",
+        re.IGNORECASE,
+    )
+    for match in comment_pattern.finditer(content):
+        names = match.group(1)
+        for name in re.split(r"\s*,\s*", names):
+            fixtures.add(name.strip())
+
+    # Pattern: use_fixture name
+    call_pattern = re.compile(
+        r"use_fixture\s+(\w+)",
+        re.IGNORECASE,
+    )
+    for match in call_pattern.finditer(content):
+        fixtures.add(match.group(1))
+
+    return list(fixtures)

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,189 @@
+"""Tests for fixture module."""
+
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from statatest.fixtures import (
+    Fixture,
+    FixtureManager,
+    discover_conftest,
+    parse_conftest,
+    get_test_fixtures,
+)
+from statatest.models import TestFile
+
+
+def test_fixture_dataclass():
+    """Test Fixture dataclass."""
+    fixture = Fixture(
+        name="sample_panel",
+        scope="function",
+        setup_program="fixture_sample_panel",
+        teardown_program="fixture_sample_panel_teardown",
+    )
+
+    assert fixture.name == "sample_panel"
+    assert fixture.scope == "function"
+    assert fixture.setup_program == "fixture_sample_panel"
+    assert fixture.teardown_program == "fixture_sample_panel_teardown"
+
+
+def test_fixture_manager_register_and_get():
+    """Test FixtureManager registration."""
+    manager = FixtureManager()
+    fixture = Fixture(name="test_fixture", setup_program="fixture_test_fixture")
+
+    manager.register_fixture(fixture)
+
+    assert manager.get_fixture("test_fixture") == fixture
+    assert manager.get_fixture("nonexistent") is None
+
+
+def test_fixture_manager_activation():
+    """Test FixtureManager activation tracking."""
+    manager = FixtureManager()
+
+    assert not manager.is_active("sample_panel")
+
+    manager.activate("sample_panel", "function")
+    assert manager.is_active("sample_panel")
+
+    manager.deactivate("sample_panel")
+    assert not manager.is_active("sample_panel")
+
+
+def test_fixture_manager_teardown_list():
+    """Test FixtureManager teardown list by scope."""
+    manager = FixtureManager()
+
+    manager.activate("fixture1", "function")
+    manager.activate("fixture2", "module")
+    manager.activate("fixture3", "function")
+
+    function_teardowns = manager.get_teardown_list("function")
+    assert set(function_teardowns) == {"fixture1", "fixture3"}
+
+    module_teardowns = manager.get_teardown_list("module")
+    assert module_teardowns == ["fixture2"]
+
+
+def test_discover_conftest():
+    """Test conftest.do discovery."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir).resolve()
+
+        # Create directory structure
+        (tmppath / "tests").mkdir()
+        (tmppath / "tests" / "unit").mkdir()
+
+        # Create conftest files at different levels
+        (tmppath / "conftest.do").write_text("// root conftest")
+        (tmppath / "tests" / "conftest.do").write_text("// tests conftest")
+
+        # Discover from tests/unit
+        conftest_files = discover_conftest(tmppath / "tests" / "unit")
+
+        assert len(conftest_files) == 2
+        # Root comes first (use resolve() to normalize paths on macOS)
+        assert conftest_files[0].resolve() == (tmppath / "conftest.do").resolve()
+        assert conftest_files[1].resolve() == (tmppath / "tests" / "conftest.do").resolve()
+
+
+def test_parse_conftest():
+    """Test parsing fixture definitions from conftest.do."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+
+        conftest_content = """
+// Test conftest file
+
+program define fixture_sample_panel
+    clear
+    set obs 100
+end
+
+program define fixture_sample_panel_teardown
+    clear
+end
+
+program define fixture_empty_data
+    clear
+end
+
+program define helper_function
+    // This should not be detected as a fixture
+end
+"""
+        conftest_path = tmppath / "conftest.do"
+        conftest_path.write_text(conftest_content)
+
+        fixtures = parse_conftest(conftest_path)
+
+        assert len(fixtures) == 2
+
+        # Check sample_panel fixture
+        sample_panel = next(f for f in fixtures if f.name == "sample_panel")
+        assert sample_panel.setup_program == "fixture_sample_panel"
+        assert sample_panel.teardown_program == "fixture_sample_panel_teardown"
+
+        # Check empty_data fixture (no teardown)
+        empty_data = next(f for f in fixtures if f.name == "empty_data")
+        assert empty_data.setup_program == "fixture_empty_data"
+        assert empty_data.teardown_program == ""
+
+
+def test_get_test_fixtures_from_comments():
+    """Test extracting fixture requirements from test file comments."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+
+        test_content = """
+// test_example.do
+//
+// @uses_fixture: sample_panel
+// @uses_fixture: seed
+
+program define test_something
+    assert_true 1 == 1
+end
+"""
+        test_path = tmppath / "test_example.do"
+        test_path.write_text(test_content)
+
+        test_file = TestFile(
+            path=test_path,
+            markers=["unit"],
+            programs=[],
+        )
+
+        fixtures = get_test_fixtures(test_file)
+
+        assert set(fixtures) == {"sample_panel", "seed"}
+
+
+def test_get_test_fixtures_from_calls():
+    """Test extracting fixture requirements from use_fixture calls."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+
+        test_content = """
+program define test_something
+    use_fixture sample_panel
+    use_fixture empty_dataset
+    assert_true _N > 0
+end
+"""
+        test_path = tmppath / "test_example.do"
+        test_path.write_text(test_content)
+
+        test_file = TestFile(
+            path=test_path,
+            markers=[],
+            programs=[],
+        )
+
+        fixtures = get_test_fixtures(test_file)
+
+        assert set(fixtures) == {"sample_panel", "empty_dataset"}


### PR DESCRIPTION
## Summary

This PR adds a pytest-inspired fixture system for reusable test setup and teardown.

### Added
- `use_fixture` command for requesting fixtures by name
- Built-in fixtures:
  - `fixture_tempfile` - Temporary file path
  - `fixture_empty_dataset` - Empty dataset with optional observation count
  - `fixture_seed` - Reproducible random seed
- Fixture scoping (function, module, session)
- Automatic `conftest.do` discovery in directory hierarchy
- Python `fixtures.py` module for fixture management
- Example in `examples/fixtures/`
- 8 new Python tests for fixture functionality

### Changed
- Updated test runner to load conftest.do files
- Updated README with fixture documentation
- Updated CHANGELOG

## Test Plan

- [x] All 22 Python tests pass
- [x] Stata example tests pass (`statatest examples/fixtures/`)
- [x] Simple example still works (`statatest examples/simple/`)