### PR TITLE
feat(coverage): add instrumentation and pre-commit hooks

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,13 @@
+{
+  "default": true,
+  "MD013": {
+    "line_length": 100,
+    "code_blocks": false,
+    "tables": false
+  },
+  "MD033": false,
+  "MD041": false,
+  "MD024": {
+    "siblings_only": true
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,88 @@
+# Pre-commit hooks for statatest
+# See https://pre-commit.com for more information
+
+repos:
+  # Essential security and file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-json
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-ast
+
+  # Python code formatting and linting with ruff (faster than black/isort/flake8)
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      - id: ruff
+        name: 🐍 Lint Python code with ruff
+        args: ['--fix']
+        types_or: [python, pyi]
+        stages: [pre-commit]
+      - id: ruff-format
+        name: 🐍 Format Python code with ruff
+        types_or: [python, pyi]
+        stages: [pre-commit]
+
+  # Type checking with mypy (runs on push only)
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.14.1
+    hooks:
+      - id: mypy
+        name: 🐍 Check Python types with mypy
+        args: ['--ignore-missing-imports', '--strict']
+        additional_dependencies: ['click', 'rich']
+        files: '^src/statatest/'
+        stages: [pre-push, manual]
+
+  # Markdown formatting with prettier
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        name: 📝 Format Markdown with prettier
+        types: [markdown]
+        args: ['--prose-wrap', 'always', '--print-width', '80']
+        stages: [pre-commit]
+
+  # Markdown linting (check only, runs on push)
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.43.0
+    hooks:
+      - id: markdownlint
+        name: 📝 Lint Markdown formatting
+        args: ['--config', '.markdownlintrc']
+        stages: [pre-push, manual]
+
+  # Stata .ado file checks (custom)
+  - repo: local
+    hooks:
+      - id: stata-ado-check
+        name: 📊 Check Stata .ado files
+        entry: bash
+        args:
+          - -c
+          - |
+            # Check .ado files have version statement
+            for file in $(git diff --cached --name-only | grep '\.ado$'); do
+              if [ -f "$file" ] && ! grep -q "^version " "$file" && ! grep -q "^    version " "$file"; then
+                echo "Missing 'version' statement in $file"
+                exit 1
+              fi
+            done
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+# Global settings
+default_language_version:
+  python: python3
+
+fail_fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixture scoping: function, module, session
 - Automatic `conftest.do` discovery in directory hierarchy
 - Fixture example in `examples/fixtures/`
-- Python tests for fixture module (8 new tests)
+- Coverage instrumentation module (`instrument.py`)
+  - SMCL comment markers for invisible coverage tracking
+  - Automatic instrumentation to `.statatest/instrumented/` directory
+  - Line number mapping for accurate reporting
+- Enhanced coverage module with `FileCoverage` and `CoverageReport` classes
+- HTML coverage report generation
+- Pre-commit hooks for Python, Markdown, and Stata
+- Release-please for automatic changelog generation
+- Python tests for fixture and coverage modules (48 total tests)
 
 ### Changed
 

--- a/src/statatest/coverage.py
+++ b/src/statatest/coverage.py
@@ -1,25 +1,206 @@
-"""Coverage collection and report generation for statatest."""
+"""Coverage collection and report generation for statatest.
+
+This module handles:
+1. Setting up instrumented source files
+2. Collecting coverage from SMCL logs
+3. Aggregating coverage across test runs
+4. Generating reports (LCOV, HTML)
+"""
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from statatest.models import TestResult
-from statatest.report import generate_lcov as _generate_lcov
+
+# Pattern to extract coverage markers from SMCL logs
+# Format: {* COV:filename:lineno }
+COVERAGE_PATTERN = re.compile(r"\{\*\s*COV:([^:]+):(\d+)\s*\}")
+
+
+@dataclass
+class FileCoverage:
+    """Coverage data for a single source file."""
+
+    filepath: str
+    lines_hit: set[int] = field(default_factory=set)
+    lines_total: set[int] = field(default_factory=set)
+
+    @property
+    def coverage_percent(self) -> float:
+        """Calculate coverage percentage."""
+        if not self.lines_total:
+            return 100.0
+        return len(self.lines_hit & self.lines_total) / len(self.lines_total) * 100
+
+    @property
+    def lines_covered(self) -> int:
+        """Number of lines covered."""
+        return len(self.lines_hit & self.lines_total)
+
+    @property
+    def lines_missed(self) -> int:
+        """Number of lines not covered."""
+        return len(self.lines_total - self.lines_hit)
+
+
+@dataclass
+class CoverageReport:
+    """Aggregated coverage report across all files."""
+
+    files: dict[str, FileCoverage] = field(default_factory=dict)
+
+    def add_hit(self, filename: str, lineno: int) -> None:
+        """Record a coverage hit."""
+        if filename not in self.files:
+            self.files[filename] = FileCoverage(filepath=filename)
+        self.files[filename].lines_hit.add(lineno)
+
+    def set_total_lines(self, filename: str, lines: set[int]) -> None:
+        """Set the total instrumentable lines for a file."""
+        if filename not in self.files:
+            self.files[filename] = FileCoverage(filepath=filename)
+        self.files[filename].lines_total = lines
+
+    @property
+    def total_lines(self) -> int:
+        """Total number of instrumentable lines."""
+        return sum(len(f.lines_total) for f in self.files.values())
+
+    @property
+    def covered_lines(self) -> int:
+        """Total number of covered lines."""
+        return sum(f.lines_covered for f in self.files.values())
+
+    @property
+    def coverage_percent(self) -> float:
+        """Overall coverage percentage."""
+        if self.total_lines == 0:
+            return 100.0
+        return self.covered_lines / self.total_lines * 100
+
+
+def parse_smcl_log(smcl_content: str) -> dict[str, set[int]]:
+    """Extract coverage hits from SMCL log content.
+
+    Args:
+        smcl_content: Raw SMCL log content
+
+    Returns:
+        Dictionary mapping filenames to sets of line numbers hit
+    """
+    hits: dict[str, set[int]] = {}
+
+    for match in COVERAGE_PATTERN.finditer(smcl_content):
+        filename, lineno = match.group(1), int(match.group(2))
+        if filename not in hits:
+            hits[filename] = set()
+        hits[filename].add(lineno)
+
+    return hits
+
+
+def aggregate_coverage(results: list[TestResult]) -> CoverageReport:
+    """Aggregate coverage data from multiple test results.
+
+    Args:
+        results: List of TestResult objects
+
+    Returns:
+        Aggregated CoverageReport
+    """
+    report = CoverageReport()
+
+    for result in results:
+        for filename, lines in result.coverage_hits.items():
+            for lineno in lines:
+                report.add_hit(filename, lineno)
+
+    return report
 
 
 def generate_lcov(results: list[TestResult], output_path: Path) -> None:
     """Generate LCOV coverage report.
 
-    Wrapper around report.generate_lcov for API consistency.
+    Args:
+        results: List of TestResult objects with coverage data
+        output_path: Path to write the LCOV file
     """
-    _generate_lcov(results, output_path)
+    # Aggregate coverage
+    coverage = aggregate_coverage(results)
+
+    lines: list[str] = []
+    lines.append("TN:statatest")
+
+    for filename, file_cov in sorted(coverage.files.items()):
+        lines.append(f"SF:{filename}")
+
+        # Write all hit lines
+        for lineno in sorted(file_cov.lines_hit):
+            lines.append(f"DA:{lineno},1")
+
+        # Summary
+        lines.append(f"LF:{len(file_cov.lines_total) or len(file_cov.lines_hit)}")
+        lines.append(f"LH:{len(file_cov.lines_hit)}")
+        lines.append("end_of_record")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines), encoding="utf-8")
 
 
 def generate_html(results: list[TestResult], output_dir: Path) -> None:
     """Generate HTML coverage report.
 
-    Wrapper around report.generate_html for API consistency.
+    Args:
+        results: List of TestResult objects with coverage data
+        output_dir: Directory to write HTML files
     """
-    from statatest.report import generate_html as _generate_html
-    _generate_html(results, output_dir)
+    # Aggregate coverage
+    coverage = aggregate_coverage(results)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Generate index.html
+    html_lines = [
+        "<!DOCTYPE html>",
+        "<html>",
+        "<head>",
+        "<title>statatest Coverage Report</title>",
+        "<style>",
+        "body { font-family: sans-serif; margin: 20px; }",
+        "table { border-collapse: collapse; width: 100%; }",
+        "th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }",
+        "th { background-color: #4CAF50; color: white; }",
+        "tr:nth-child(even) { background-color: #f2f2f2; }",
+        ".high { color: green; }",
+        ".medium { color: orange; }",
+        ".low { color: red; }",
+        "</style>",
+        "</head>",
+        "<body>",
+        f"<h1>statatest Coverage Report</h1>",
+        f"<p>Overall coverage: <strong>{coverage.coverage_percent:.1f}%</strong></p>",
+        "<table>",
+        "<tr><th>File</th><th>Lines</th><th>Covered</th><th>Coverage</th></tr>",
+    ]
+
+    for filename, file_cov in sorted(coverage.files.items()):
+        pct = file_cov.coverage_percent
+        css_class = "high" if pct >= 80 else "medium" if pct >= 50 else "low"
+        total = len(file_cov.lines_total) or len(file_cov.lines_hit)
+        covered = len(file_cov.lines_hit)
+        html_lines.append(
+            f"<tr><td>{filename}</td><td>{total}</td><td>{covered}</td>"
+            f"<td class='{css_class}'>{pct:.1f}%</td></tr>"
+        )
+
+    html_lines.extend([
+        "</table>",
+        "</body>",
+        "</html>",
+    ])
+
+    index_path = output_dir / "index.html"
+    index_path.write_text("\n".join(html_lines), encoding="utf-8")

--- a/src/statatest/instrument.py
+++ b/src/statatest/instrument.py
@@ -1,0 +1,196 @@
+"""Source code instrumentation for coverage collection.
+
+This module instruments Stata .ado files with invisible SMCL coverage markers
+that are preserved in .smcl log files but invisible in rendered output.
+
+The instrumentation process:
+1. Copy source files to .statatest/instrumented/
+2. Inject SMCL comment markers: {* COV:filename:lineno }
+3. Run tests with instrumented files
+4. Parse .smcl logs to extract coverage data
+5. Map coverage back to original file paths
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+# Lines that should NOT be instrumented
+SKIP_PATTERNS = [
+    r"^\s*$",  # Empty lines
+    r"^\s*\*",  # Comment lines
+    r"^\s*//",  # Comment lines
+    r"^\s*/\*",  # Block comment start
+    r"^\s*\*/",  # Block comment end
+    r"^\s*program\s+define\s+",  # Program definition
+    r"^\s*program\s+drop\s+",  # Program drop
+    r"^\s*end\s*$",  # Program end
+    r"^\s*version\s+",  # Version statement
+    r"^\s*syntax\s+",  # Syntax statement
+    r"^\s*args\s+",  # Args statement
+    r"^\s*marksample\s+",  # Marksample
+    r"^\s*mata\s*:",  # Mata start
+    r"^\s*mata\s*$",  # Mata start
+    r"^\s*end\s+mata",  # Mata end
+    r"^\s*\{",  # Block start
+    r"^\s*\}",  # Block end
+]
+
+SKIP_REGEX = re.compile("|".join(SKIP_PATTERNS), re.IGNORECASE)
+
+
+def should_instrument_line(line: str) -> bool:
+    """Check if a line should be instrumented.
+
+    Args:
+        line: The source code line
+
+    Returns:
+        True if the line should be instrumented
+    """
+    # Skip lines matching skip patterns
+    if SKIP_REGEX.match(line):
+        return False
+
+    # Skip continuation lines (start with ///)
+    if line.strip().startswith("///"):
+        return False
+
+    # Skip lines that are just closing braces or keywords
+    stripped = line.strip().lower()
+    if stripped in ("}", "else", "else {"):
+        return False
+
+    return True
+
+
+def instrument_file(source_path: Path, dest_path: Path) -> dict[int, int]:
+    """Instrument a single .ado file with SMCL coverage markers.
+
+    Args:
+        source_path: Path to the original .ado file
+        dest_path: Path where instrumented file will be written
+
+    Returns:
+        Mapping of instrumented line numbers to original line numbers
+    """
+    content = source_path.read_text(encoding="utf-8")
+    lines = content.split("\n")
+
+    # Track line number mapping (instrumented -> original)
+    line_map: dict[int, int] = {}
+
+    instrumented_lines: list[str] = []
+    filename = source_path.name
+
+    for orig_lineno, line in enumerate(lines, start=1):
+        if should_instrument_line(line):
+            # Insert SMCL coverage marker before the line
+            # Format: display `"{* COV:filename:lineno }"'
+            marker = f'display `"{{* COV:{filename}:{orig_lineno} }}"\'  '
+            instrumented_lines.append(marker)
+            line_map[len(instrumented_lines)] = orig_lineno
+            instrumented_lines.append(line)
+        else:
+            instrumented_lines.append(line)
+
+    # Write instrumented file
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    dest_path.write_text("\n".join(instrumented_lines), encoding="utf-8")
+
+    return line_map
+
+
+def instrument_directory(
+    source_dir: Path,
+    dest_dir: Path,
+    patterns: list[str] | None = None,
+) -> dict[str, dict[int, int]]:
+    """Instrument all .ado files in a directory.
+
+    Args:
+        source_dir: Directory containing source .ado files
+        dest_dir: Directory where instrumented files will be written
+        patterns: Glob patterns for files to instrument (default: ["*.ado"])
+
+    Returns:
+        Dictionary mapping filenames to their line number mappings
+    """
+    if patterns is None:
+        patterns = ["*.ado"]
+
+    all_maps: dict[str, dict[int, int]] = {}
+
+    for pattern in patterns:
+        for source_path in source_dir.glob(pattern):
+            if source_path.is_file():
+                dest_path = dest_dir / source_path.name
+                line_map = instrument_file(source_path, dest_path)
+                all_maps[source_path.name] = line_map
+
+    return all_maps
+
+
+def setup_instrumented_environment(
+    source_dirs: list[Path],
+    work_dir: Path,
+    patterns: list[str] | None = None,
+) -> tuple[Path, dict[str, dict[int, int]]]:
+    """Set up an instrumented environment for coverage collection.
+
+    Args:
+        source_dirs: List of directories containing source files
+        work_dir: Working directory (usually project root)
+        patterns: Glob patterns for files to instrument
+
+    Returns:
+        Tuple of (instrumented_dir, all_line_maps)
+    """
+    # Create .statatest/instrumented directory
+    instrumented_dir = work_dir / ".statatest" / "instrumented"
+    if instrumented_dir.exists():
+        shutil.rmtree(instrumented_dir)
+    instrumented_dir.mkdir(parents=True)
+
+    all_maps: dict[str, dict[int, int]] = {}
+
+    for source_dir in source_dirs:
+        if source_dir.exists():
+            maps = instrument_directory(source_dir, instrumented_dir, patterns)
+            all_maps.update(maps)
+
+    return instrumented_dir, all_maps
+
+
+def cleanup_instrumented_environment(work_dir: Path) -> None:
+    """Clean up the instrumented environment.
+
+    Args:
+        work_dir: Working directory containing .statatest folder
+    """
+    statatest_dir = work_dir / ".statatest"
+    if statatest_dir.exists():
+        shutil.rmtree(statatest_dir)
+
+
+def get_total_lines(source_path: Path) -> set[int]:
+    """Get the set of instrumentable line numbers in a source file.
+
+    Args:
+        source_path: Path to the source file
+
+    Returns:
+        Set of line numbers that are instrumentable
+    """
+    content = source_path.read_text(encoding="utf-8")
+    lines = content.split("\n")
+
+    total_lines: set[int] = set()
+
+    for lineno, line in enumerate(lines, start=1):
+        if should_instrument_line(line):
+            total_lines.add(lineno)
+
+    return total_lines

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,222 @@
+"""Tests for coverage collection module."""
+
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from statatest.coverage import (
+    FileCoverage,
+    CoverageReport,
+    parse_smcl_log,
+    aggregate_coverage,
+    generate_lcov,
+    generate_html,
+)
+from statatest.models import TestResult
+
+
+class TestFileCoverage:
+    """Tests for FileCoverage dataclass."""
+
+    def test_coverage_percent_full(self):
+        """Test coverage percentage when all lines are covered."""
+        cov = FileCoverage(
+            filepath="test.ado",
+            lines_hit={1, 2, 3},
+            lines_total={1, 2, 3},
+        )
+        assert cov.coverage_percent == 100.0
+
+    def test_coverage_percent_partial(self):
+        """Test coverage percentage with partial coverage."""
+        cov = FileCoverage(
+            filepath="test.ado",
+            lines_hit={1, 2},
+            lines_total={1, 2, 3, 4},
+        )
+        assert cov.coverage_percent == 50.0
+
+    def test_coverage_percent_empty_total(self):
+        """Test coverage percentage when no lines are expected."""
+        cov = FileCoverage(filepath="test.ado")
+        assert cov.coverage_percent == 100.0
+
+    def test_lines_covered_and_missed(self):
+        """Test lines covered and missed properties."""
+        cov = FileCoverage(
+            filepath="test.ado",
+            lines_hit={1, 2, 5},
+            lines_total={1, 2, 3, 4, 5},
+        )
+        assert cov.lines_covered == 3
+        assert cov.lines_missed == 2
+
+
+class TestCoverageReport:
+    """Tests for CoverageReport dataclass."""
+
+    def test_add_hit(self):
+        """Test adding coverage hits."""
+        report = CoverageReport()
+        report.add_hit("test.ado", 1)
+        report.add_hit("test.ado", 2)
+        report.add_hit("other.ado", 5)
+
+        assert "test.ado" in report.files
+        assert 1 in report.files["test.ado"].lines_hit
+        assert 2 in report.files["test.ado"].lines_hit
+        assert 5 in report.files["other.ado"].lines_hit
+
+    def test_set_total_lines(self):
+        """Test setting total lines for a file."""
+        report = CoverageReport()
+        report.set_total_lines("test.ado", {1, 2, 3, 4, 5})
+
+        assert report.files["test.ado"].lines_total == {1, 2, 3, 4, 5}
+
+    def test_overall_coverage(self):
+        """Test overall coverage calculation."""
+        report = CoverageReport()
+        report.add_hit("test.ado", 1)
+        report.add_hit("test.ado", 2)
+        report.set_total_lines("test.ado", {1, 2, 3, 4})
+
+        assert report.total_lines == 4
+        assert report.covered_lines == 2
+        assert report.coverage_percent == 50.0
+
+
+class TestParseSMCLLog:
+    """Tests for parse_smcl_log function."""
+
+    def test_parse_single_marker(self):
+        """Test parsing a single coverage marker."""
+        smcl = """
+{smcl}
+{txt}
+{* COV:test.ado:5 }
+{res}some output
+"""
+        hits = parse_smcl_log(smcl)
+
+        assert "test.ado" in hits
+        assert 5 in hits["test.ado"]
+
+    def test_parse_multiple_markers(self):
+        """Test parsing multiple coverage markers."""
+        smcl = """
+{* COV:test.ado:1 }
+{* COV:test.ado:2 }
+{* COV:other.ado:10 }
+"""
+        hits = parse_smcl_log(smcl)
+
+        assert hits["test.ado"] == {1, 2}
+        assert hits["other.ado"] == {10}
+
+    def test_parse_no_markers(self):
+        """Test parsing content without markers."""
+        smcl = """
+{smcl}
+just regular output
+"""
+        hits = parse_smcl_log(smcl)
+
+        assert hits == {}
+
+
+class TestAggregateCoverage:
+    """Tests for aggregate_coverage function."""
+
+    def test_aggregate_single_result(self):
+        """Test aggregating coverage from a single result."""
+        results = [
+            TestResult(
+                test_file="test.do",
+                passed=True,
+                duration=1.0,
+                coverage_hits={"test.ado": {1, 2, 3}},
+            ),
+        ]
+
+        report = aggregate_coverage(results)
+
+        assert "test.ado" in report.files
+        assert report.files["test.ado"].lines_hit == {1, 2, 3}
+
+    def test_aggregate_multiple_results(self):
+        """Test aggregating coverage from multiple results."""
+        results = [
+            TestResult(
+                test_file="test1.do",
+                passed=True,
+                duration=1.0,
+                coverage_hits={"test.ado": {1, 2}},
+            ),
+            TestResult(
+                test_file="test2.do",
+                passed=True,
+                duration=1.0,
+                coverage_hits={"test.ado": {2, 3, 4}},
+            ),
+        ]
+
+        report = aggregate_coverage(results)
+
+        # Union of all hits
+        assert report.files["test.ado"].lines_hit == {1, 2, 3, 4}
+
+
+class TestGenerateLCOV:
+    """Tests for generate_lcov function."""
+
+    def test_generate_lcov_format(self):
+        """Test LCOV output format."""
+        results = [
+            TestResult(
+                test_file="test.do",
+                passed=True,
+                duration=1.0,
+                coverage_hits={"test.ado": {1, 2, 5}},
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "coverage.lcov"
+            generate_lcov(results, output_path)
+
+            content = output_path.read_text()
+
+            assert "TN:statatest" in content
+            assert "SF:test.ado" in content
+            assert "DA:1,1" in content
+            assert "DA:2,1" in content
+            assert "DA:5,1" in content
+            assert "end_of_record" in content
+
+
+class TestGenerateHTML:
+    """Tests for generate_html function."""
+
+    def test_generate_html_creates_index(self):
+        """Test HTML report generation."""
+        results = [
+            TestResult(
+                test_file="test.do",
+                passed=True,
+                duration=1.0,
+                coverage_hits={"test.ado": {1, 2, 3}},
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "htmlcov"
+            generate_html(results, output_dir)
+
+            index_path = output_dir / "index.html"
+            assert index_path.exists()
+
+            content = index_path.read_text()
+            assert "statatest Coverage Report" in content
+            assert "test.ado" in content

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,0 +1,219 @@
+"""Tests for source code instrumentation module."""
+
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from statatest.instrument import (
+    should_instrument_line,
+    instrument_file,
+    instrument_directory,
+    setup_instrumented_environment,
+    cleanup_instrumented_environment,
+    get_total_lines,
+)
+
+
+class TestShouldInstrumentLine:
+    """Tests for should_instrument_line function."""
+
+    def test_instrument_regular_code(self):
+        """Regular code lines should be instrumented."""
+        assert should_instrument_line("    gen x = 1")
+        assert should_instrument_line("local foo = 42")
+        assert should_instrument_line("    regress y x")
+
+    def test_skip_empty_lines(self):
+        """Empty lines should not be instrumented."""
+        assert not should_instrument_line("")
+        assert not should_instrument_line("   ")
+        assert not should_instrument_line("\t")
+
+    def test_skip_comment_lines(self):
+        """Comment lines should not be instrumented."""
+        assert not should_instrument_line("* This is a comment")
+        assert not should_instrument_line("// Another comment")
+        assert not should_instrument_line("/* Block comment start")
+        assert not should_instrument_line("*/ Block comment end")
+
+    def test_skip_program_structure(self):
+        """Program structure lines should not be instrumented."""
+        assert not should_instrument_line("program define myprogram")
+        assert not should_instrument_line("program drop myprogram")
+        assert not should_instrument_line("end")
+        assert not should_instrument_line("    end")
+
+    def test_skip_syntax_related(self):
+        """Syntax-related lines should not be instrumented."""
+        assert not should_instrument_line("version 16")
+        assert not should_instrument_line("    syntax anything")
+        assert not should_instrument_line("    args x y z")
+        assert not should_instrument_line("    marksample touse")
+
+    def test_skip_continuation_lines(self):
+        """Continuation lines should not be instrumented."""
+        assert not should_instrument_line("///")
+        assert not should_instrument_line("    /// continuation")
+
+
+class TestInstrumentFile:
+    """Tests for instrument_file function."""
+
+    def test_instrument_simple_file(self):
+        """Test instrumenting a simple .ado file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+
+            source_content = """\
+*! myfunction v1.0
+program define myfunction
+    version 16
+    syntax anything
+    gen x = 1
+    gen y = 2
+end
+"""
+            source_path = tmppath / "myfunction.ado"
+            source_path.write_text(source_content)
+
+            dest_path = tmppath / "instrumented" / "myfunction.ado"
+            line_map = instrument_file(source_path, dest_path)
+
+            # Check file was created
+            assert dest_path.exists()
+
+            # Check instrumented content
+            instrumented = dest_path.read_text()
+            assert "{* COV:myfunction.ado:5 }" in instrumented
+            assert "{* COV:myfunction.ado:6 }" in instrumented
+
+            # Check line map
+            assert 5 in line_map.values()
+            assert 6 in line_map.values()
+
+    def test_instrument_preserves_structure(self):
+        """Test that instrumentation preserves program structure."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+
+            source_content = """\
+program define test
+    version 16
+    local x = 1
+    if `x' == 1 {
+        display "yes"
+    }
+end
+"""
+            source_path = tmppath / "test.ado"
+            source_path.write_text(source_content)
+
+            dest_path = tmppath / "instrumented" / "test.ado"
+            instrument_file(source_path, dest_path)
+
+            instrumented = dest_path.read_text()
+
+            # Program structure should be preserved
+            assert "program define test" in instrumented
+            assert "version 16" in instrumented
+            assert "end" in instrumented
+
+
+class TestInstrumentDirectory:
+    """Tests for instrument_directory function."""
+
+    def test_instrument_multiple_files(self):
+        """Test instrumenting multiple files in a directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            source_dir = tmppath / "source"
+            source_dir.mkdir()
+
+            # Create multiple .ado files
+            (source_dir / "func1.ado").write_text("program define func1\n    gen x = 1\nend\n")
+            (source_dir / "func2.ado").write_text("program define func2\n    gen y = 2\nend\n")
+            (source_dir / "notado.txt").write_text("not an ado file")
+
+            dest_dir = tmppath / "instrumented"
+            all_maps = instrument_directory(source_dir, dest_dir)
+
+            # Check both .ado files were instrumented
+            assert "func1.ado" in all_maps
+            assert "func2.ado" in all_maps
+
+            # Check .txt file was not instrumented
+            assert not (dest_dir / "notado.txt").exists()
+
+
+class TestSetupInstrumentedEnvironment:
+    """Tests for setup_instrumented_environment function."""
+
+    def test_setup_creates_directory(self):
+        """Test that setup creates .statatest/instrumented directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            source_dir = tmppath / "source"
+            source_dir.mkdir()
+            (source_dir / "test.ado").write_text("program define test\n    gen x = 1\nend\n")
+
+            instrumented_dir, maps = setup_instrumented_environment(
+                [source_dir], tmppath
+            )
+
+            assert instrumented_dir.exists()
+            assert instrumented_dir == tmppath / ".statatest" / "instrumented"
+            assert (instrumented_dir / "test.ado").exists()
+
+
+class TestCleanupInstrumentedEnvironment:
+    """Tests for cleanup_instrumented_environment function."""
+
+    def test_cleanup_removes_directory(self):
+        """Test that cleanup removes .statatest directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+
+            # Create .statatest directory
+            statatest_dir = tmppath / ".statatest"
+            statatest_dir.mkdir()
+            (statatest_dir / "instrumented").mkdir()
+            (statatest_dir / "instrumented" / "test.ado").write_text("content")
+
+            cleanup_instrumented_environment(tmppath)
+
+            assert not statatest_dir.exists()
+
+
+class TestGetTotalLines:
+    """Tests for get_total_lines function."""
+
+    def test_get_total_lines(self):
+        """Test getting total instrumentable lines."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+
+            source_content = """\
+*! comment
+program define test
+    version 16
+    gen x = 1
+    gen y = 2
+    gen z = 3
+end
+"""
+            source_path = tmppath / "test.ado"
+            source_path.write_text(source_content)
+
+            total_lines = get_total_lines(source_path)
+
+            # Lines 4, 5, 6 should be instrumentable (gen statements)
+            assert 4 in total_lines
+            assert 5 in total_lines
+            assert 6 in total_lines
+
+            # Lines 1, 2, 3, 7 should not be instrumentable
+            assert 1 not in total_lines  # comment
+            assert 2 not in total_lines  # program define
+            assert 3 not in total_lines  # version
+            assert 7 not in total_lines  # end


### PR DESCRIPTION
## Summary

Add source code instrumentation for coverage collection and pre-commit hooks.

### Added
- `instrument.py`: Source code instrumentation module
  - SMCL comment markers (`{* COV:file:line }`) for invisible coverage tracking
  - Automatic instrumentation to `.statatest/instrumented/` directory
  - Line number mapping for accurate reporting
- Enhanced `coverage.py`:
  - `FileCoverage` and `CoverageReport` dataclasses
  - HTML coverage report generation
- Pre-commit hooks:
  - Python: ruff lint/format
  - Markdown: prettier format, markdownlint
  - Stata: .ado file checks
- Python tests: 26 new tests (48 total)

### Changed
- Updated CHANGELOG with coverage features

## Test Plan

- [x] All 48 Python tests pass
- [x] Existing Stata tests still work