### PR TITLE
docs: add MkDocs documentation website

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-material pymdown-extensions
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Tests](https://github.com/jigonr/statatest/actions/workflows/ci.yml/badge.svg)](https://github.com/jigonr/statatest/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/jigonr/statatest/branch/main/graph/badge.svg)](https://codecov.io/gh/jigonr/statatest)
+[![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://jigonr.github.io/statatest/)
 
 A pytest-inspired testing and code coverage framework for Stata.
+
+**[Documentation](https://jigonr.github.io/statatest/)** | **[GitHub](https://github.com/jigonr/statatest)** | **[PyPI](https://pypi.org/project/statatest/)**
 
 ## Features
 

--- a/docs/ci/codecov.md
+++ b/docs/ci/codecov.md
@@ -1,0 +1,184 @@
+# Codecov Integration
+
+Upload Stata code coverage to Codecov for PR comments and coverage tracking.
+
+## Setup
+
+### 1. Enable Codecov
+
+1. Go to [codecov.io](https://codecov.io)
+2. Log in with GitHub
+3. Add your repository
+
+### 2. Add Codecov Token
+
+1. Copy the upload token from Codecov
+2. Go to repository Settings > Secrets > Actions
+3. Create new secret: `CODECOV_TOKEN`
+
+### 3. Configure GitHub Actions
+
+```yaml
+# .github/workflows/tests.yml
+- name: Run tests with coverage
+  run: statatest tests/ --coverage --cov-report=lcov
+
+- name: Upload coverage to Codecov
+  uses: codecov/codecov-action@v5
+  with:
+    files: coverage.lcov
+    token: ${{ secrets.CODECOV_TOKEN }}
+```
+
+## Codecov Configuration
+
+Create `codecov.yml` in your repository root:
+
+```yaml
+# codecov.yml
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+
+    patch:
+      default:
+        target: 80%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false
+```
+
+## PR Comments
+
+Codecov automatically adds comments to pull requests showing:
+
+- Coverage diff (lines added/removed)
+- Coverage percentage change
+- Uncovered lines in the patch
+- File-by-file breakdown
+
+Example PR comment:
+
+```
+## Coverage Report
+
+| Coverage | Status |
+|----------|--------|
+| Project  | 85.3% (+0.5%) ✅ |
+| Patch    | 92.1% ✅ |
+
+### Files Changed
+
+| File | Coverage | Lines |
+|------|----------|-------|
+| myfunction.ado | 90% | 18/20 |
+| helper.ado | 75% | 15/20 |
+```
+
+## Coverage Flags
+
+Use flags to track different coverage types:
+
+```yaml
+# codecov.yml
+flags:
+  unit:
+    paths:
+      - tests/unit/
+    carryforward: true
+
+  integration:
+    paths:
+      - tests/integration/
+    carryforward: true
+```
+
+```yaml
+# .github/workflows/tests.yml
+- uses: codecov/codecov-action@v5
+  with:
+    files: coverage.lcov
+    flags: unit
+    token: ${{ secrets.CODECOV_TOKEN }}
+```
+
+## Coverage Targets
+
+Set minimum coverage requirements:
+
+```yaml
+# codecov.yml
+coverage:
+  status:
+    project:
+      default:
+        target: 80%  # Fail if below 80%
+        threshold: 2%  # Allow 2% drop
+
+    patch:
+      default:
+        target: 90%  # New code must have 90% coverage
+```
+
+## Badges
+
+Add a coverage badge to your README:
+
+```markdown
+[![codecov](https://codecov.io/gh/username/repo/branch/main/graph/badge.svg)](https://codecov.io/gh/username/repo)
+```
+
+## LCOV Format
+
+statatest generates LCOV format coverage:
+
+```
+TN:statatest
+SF:myfunction.ado
+DA:5,1
+DA:6,1
+DA:10,0
+LF:3
+LH:2
+end_of_record
+```
+
+- `TN`: Test name
+- `SF`: Source file
+- `DA:line,hits`: Line coverage data
+- `LF`: Lines found (total)
+- `LH`: Lines hit (covered)
+
+## Troubleshooting
+
+### Coverage Not Uploading
+
+1. Check token is correctly set
+2. Verify LCOV file exists: `ls -la coverage.lcov`
+3. Check Codecov action logs for errors
+
+### Coverage Too Low
+
+1. Add more tests covering edge cases
+2. Use coverage HTML report to identify uncovered lines:
+   ```bash
+   statatest tests/ --coverage --cov-report=html
+   open htmlcov/index.html
+   ```
+
+### Flaky Coverage
+
+If coverage varies between runs:
+
+1. Ensure tests are deterministic (use `fixture_seed`)
+2. Check for conditional code paths
+3. Use `carryforward: true` in flags

--- a/docs/ci/github-actions.md
+++ b/docs/ci/github-actions.md
@@ -1,0 +1,214 @@
+# GitHub Actions
+
+Run Stata tests in GitHub Actions CI/CD pipelines.
+
+## Basic Workflow
+
+```yaml
+# .github/workflows/tests.yml
+name: Stata Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: dataeditors/stata18:latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install statatest
+        run: pip install statatest
+
+      - name: Set up Stata license
+        run: |
+          echo "${{ secrets.STATA_LIC_B64 }}" | base64 -d > /usr/local/stata/stata.lic
+
+      - name: Run tests
+        run: statatest tests/ --junit-xml=junit.xml
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: junit.xml
+```
+
+## With Coverage
+
+```yaml
+# .github/workflows/tests.yml
+name: Stata Tests with Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: dataeditors/stata18:latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install statatest
+        run: pip install statatest
+
+      - name: Set up Stata license
+        run: |
+          echo "${{ secrets.STATA_LIC_B64 }}" | base64 -d > /usr/local/stata/stata.lic
+
+      - name: Run tests with coverage
+        run: |
+          statatest tests/ \
+            --coverage \
+            --cov-report=lcov \
+            --junit-xml=junit.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: |
+            junit.xml
+            coverage.lcov
+```
+
+## Stata License Setup
+
+### 1. Encode your license
+
+```bash
+base64 -i stata.lic | pbcopy  # macOS
+base64 stata.lic | xclip      # Linux
+```
+
+### 2. Add to GitHub Secrets
+
+1. Go to repository Settings > Secrets > Actions
+2. Create new secret: `STATA_LIC_B64`
+3. Paste the base64-encoded license
+
+## Docker Images
+
+### dataeditors/stata18
+
+Official Stata Docker image from AEA Data Editor:
+
+```yaml
+container:
+  image: dataeditors/stata18:latest
+```
+
+License path: `/usr/local/stata/stata.lic`
+
+### Custom Image
+
+```dockerfile
+FROM dataeditors/stata18:latest
+
+# Install Python
+RUN apt-get update && apt-get install -y python3 python3-pip
+
+# Install statatest
+RUN pip3 install statatest
+```
+
+## Matrix Testing
+
+Test across multiple Stata versions:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        stata-version: ["17", "18"]
+    container:
+      image: dataeditors/stata${{ matrix.stata-version }}:latest
+
+    steps:
+      - uses: actions/checkout@v4
+      # ... rest of steps
+```
+
+## Test Result Reporting
+
+GitHub Actions can display test results in PR comments using JUnit XML:
+
+```yaml
+- name: Publish Test Results
+  uses: EnricoMi/publish-unit-test-result-action@v2
+  if: always()
+  with:
+    files: junit.xml
+```
+
+## Caching
+
+Cache pip packages for faster builds:
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: ~/.cache/pip
+    key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+    restore-keys: |
+      ${{ runner.os }}-pip-
+```
+
+## Troubleshooting
+
+### License Issues
+
+```
+r(601): license not found
+```
+
+Check that:
+1. `STATA_LIC_B64` secret is correctly set
+2. License path matches Docker image location
+3. Base64 encoding is correct
+
+### Permission Denied
+
+```
+stata-mp: Permission denied
+```
+
+Ensure the container runs with appropriate permissions:
+
+```yaml
+container:
+  image: dataeditors/stata18:latest
+  options: --user root
+```

--- a/docs/getting-started/first-test.md
+++ b/docs/getting-started/first-test.md
@@ -1,0 +1,125 @@
+# Writing Your First Test
+
+## Test File Structure
+
+A statatest test file is a regular Stata `.do` file with some conventions:
+
+```stata
+// tests/test_myfunction.do
+
+// Markers for filtering (optional)
+// @marker: unit
+
+// Clear state
+clear all
+
+// Define test programs
+program define test_something
+    // Setup
+    clear
+    set obs 100
+    gen x = rnormal()
+
+    // Action
+    myfunction x, gen(y)
+
+    // Assert
+    assert_var_exists y
+    assert_obs_count 100
+end
+
+// Run the test
+test_something
+
+display "All tests passed!"
+```
+
+## Test Naming Convention
+
+- Test files: `test_*.do`
+- Test programs: `test_*` (optional but recommended)
+
+## Basic Assertions
+
+```stata
+// Value equality
+assert_equal "`r(result)'", expected("expected_value")
+
+// Boolean assertions
+assert_true _N > 0
+assert_false missing(x)
+
+// Variable checks
+assert_var_exists myvar
+assert_obs_count 100
+
+// Numeric comparisons
+assert_approx_equal r(mean), expected(0.5) tol(0.01)
+assert_in_range r(sd), min(0) max(10)
+
+// Command behavior
+assert_error "invalid_command"
+assert_noerror "summarize x"
+
+// File checks
+assert_file_exists "data/output.dta"
+```
+
+## Using Markers
+
+Markers help organize and filter tests:
+
+```stata
+// @marker: unit
+// @marker: slow
+// @marker: integration
+```
+
+Run only specific markers:
+
+```bash
+statatest tests/ -m unit
+statatest tests/ -m "not slow"
+```
+
+## Using Fixtures
+
+For reusable setup, use `conftest.do`:
+
+```stata
+// tests/conftest.do
+
+program define fixture_sample_data
+    clear
+    set obs 100
+    gen x = rnormal()
+    gen y = x * 2 + rnormal()
+end
+```
+
+```stata
+// tests/test_analysis.do
+// @uses_fixture: sample_data
+
+program define test_correlation
+    use_fixture sample_data
+    correlate x y
+    assert_true r(rho) > 0.5
+end
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+statatest tests/
+
+# Run specific file
+statatest tests/test_myfunction.do
+
+# Run with keyword filter
+statatest tests/ -k "regression"
+
+# Verbose output
+statatest tests/ --verbose
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,62 @@
+# Installation
+
+## Requirements
+
+- **Python**: 3.11 or higher
+- **Stata**: 16 or higher
+
+## Using uv (Recommended)
+
+[uv](https://docs.astral.sh/uv/) is a fast Python package manager.
+
+```bash
+# Install globally
+uv tool install statatest
+
+# Or run directly without installing
+uvx statatest tests/
+```
+
+## Using pip
+
+```bash
+pip install statatest
+```
+
+## Development Installation
+
+For contributing or development:
+
+```bash
+git clone https://github.com/jigonr/statatest.git
+cd statatest
+uv sync --dev
+```
+
+## Verify Installation
+
+```bash
+statatest --version
+```
+
+Should output:
+
+```
+statatest version 0.1.0
+```
+
+## Stata Configuration
+
+statatest needs to find your Stata executable. By default, it looks for
+`stata-mp`. You can configure this in `statatest.toml`:
+
+```toml
+[tool.statatest]
+stata_executable = "stata-se"  # or "stata", "stata-mp"
+```
+
+Or via environment variable:
+
+```bash
+export STATA_EXECUTABLE=stata-se
+```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,79 @@
+# Quick Start
+
+## Create Your First Test
+
+Create a test file `tests/test_example.do`:
+
+```stata
+// tests/test_example.do
+// @marker: unit
+
+clear all
+
+program define test_basic_math
+    assert_equal 2 + 2, expected(4)
+    assert_true 5 > 3
+    assert_false 1 > 2
+end
+
+test_basic_math
+display "Test passed!"
+```
+
+## Run Tests
+
+```bash
+statatest tests/
+```
+
+Output:
+
+```
+statatest v0.1.0
+Collecting tests from: tests
+Found 1 test file(s)
+
+.
+
+============================================================
+1 passed in 0.25s
+```
+
+## Run with Verbose Output
+
+```bash
+statatest tests/ --verbose
+```
+
+Output:
+
+```
+statatest v0.1.0
+Collecting tests from: tests
+Found 1 test file(s)
+
+Running: tests/test_example.do PASSED (0.25s)
+
+============================================================
+1 passed in 0.25s
+```
+
+## Generate JUnit XML for CI
+
+```bash
+statatest tests/ --junit-xml=junit.xml
+```
+
+## Enable Coverage
+
+```bash
+statatest tests/ --coverage --cov-report=lcov
+```
+
+## Create Configuration
+
+```bash
+statatest --init
+```
+
+Creates `statatest.toml` with default settings.

--- a/docs/guide/assertions.md
+++ b/docs/guide/assertions.md
@@ -1,0 +1,179 @@
+# Assertions
+
+statatest provides a rich assertion library built on Stata's native `assert`
+command, with detailed failure messages.
+
+## Available Assertions
+
+### assert_equal
+
+Check that two values are equal.
+
+```stata
+assert_equal actual, expected(value) [message(str)]
+```
+
+**Example:**
+
+```stata
+summarize x
+assert_equal "`r(N)'", expected("100")
+assert_equal "`r(mean)'", expected("0.5") message("Mean should be 0.5")
+```
+
+### assert_true
+
+Check that a condition is true.
+
+```stata
+assert_true condition
+```
+
+**Example:**
+
+```stata
+assert_true _N > 0
+assert_true r(mean) > 0
+assert_true inlist("`region'", "EU", "GB")
+```
+
+### assert_false
+
+Check that a condition is false.
+
+```stata
+assert_false condition
+```
+
+**Example:**
+
+```stata
+assert_false _N == 0
+assert_false missing(x)
+```
+
+### assert_var_exists
+
+Check that a variable exists in the dataset.
+
+```stata
+assert_var_exists varname [, type(str)]
+```
+
+**Example:**
+
+```stata
+assert_var_exists x
+assert_var_exists firm_id, type(numeric)
+assert_var_exists name, type(string)
+```
+
+### assert_obs_count
+
+Check the number of observations.
+
+```stata
+assert_obs_count expected [if] [, message(str)]
+```
+
+**Example:**
+
+```stata
+assert_obs_count 100
+assert_obs_count 50 if foreign == 1
+```
+
+### assert_approx_equal
+
+Check that two numbers are approximately equal (for floating point).
+
+```stata
+assert_approx_equal value, expected(num) [tol(num)] [message(str)]
+```
+
+**Example:**
+
+```stata
+assert_approx_equal r(mean), expected(0.5) tol(0.01)
+assert_approx_equal e(r2), expected(0.85) tol(0.05)
+```
+
+### assert_in_range
+
+Check that a value is within a range.
+
+```stata
+assert_in_range value, min(num) max(num) [message(str)]
+```
+
+**Example:**
+
+```stata
+assert_in_range r(mean), min(0) max(100)
+assert_in_range e(r2), min(0) max(1)
+```
+
+### assert_error
+
+Check that a command produces an error.
+
+```stata
+assert_error "command"
+```
+
+**Example:**
+
+```stata
+assert_error "drop nonexistent_var"
+assert_error "regress y"  // Missing independent variables
+```
+
+### assert_noerror
+
+Check that a command executes without error.
+
+```stata
+assert_noerror "command"
+```
+
+**Example:**
+
+```stata
+assert_noerror "summarize x"
+assert_noerror "regress y x"
+```
+
+### assert_file_exists
+
+Check that a file exists.
+
+```stata
+assert_file_exists "path/to/file"
+```
+
+**Example:**
+
+```stata
+assert_file_exists "data/output.dta"
+assert_file_exists "$HOME/config.txt"
+```
+
+## Failure Messages
+
+All assertions provide detailed failure messages:
+
+```
+ASSERTION FAILED: assert_equal
+  Expected: 100
+  Actual:   99
+  Message:  Observation count mismatch
+```
+
+## Custom Messages
+
+Add context to failures with the `message()` option:
+
+```stata
+assert_equal "`r(N)'", expected("100") message("Sample size after filtering")
+assert_true e(r2) > 0.5, message("R-squared should be above 0.5")
+```

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,0 +1,119 @@
+# Configuration
+
+statatest uses a TOML configuration file for project settings.
+
+## Configuration File
+
+Create `statatest.toml` in your project root:
+
+```toml
+[tool.statatest]
+# Test discovery
+testpaths = ["tests"]
+test_files = ["test_*.do"]
+
+# Stata executable (auto-detected if not set)
+stata_executable = "stata-mp"
+
+[tool.statatest.coverage]
+# Source directories to instrument
+source = ["code/functions"]
+
+# Files/patterns to exclude from coverage
+omit = ["tests/*", "*_test.ado"]
+
+[tool.statatest.reporting]
+# JUnit XML output for CI
+junit_xml = "junit.xml"
+
+# LCOV output for Codecov
+lcov = "coverage.lcov"
+```
+
+## Initialize Configuration
+
+Generate a configuration file with defaults:
+
+```bash
+statatest --init
+```
+
+## Configuration Options
+
+### Test Discovery
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `testpaths` | list | `["tests"]` | Directories to search for tests |
+| `test_files` | list | `["test_*.do"]` | Glob patterns for test files |
+| `stata_executable` | string | auto | Path to Stata executable |
+
+### Coverage Settings
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `source` | list | `[]` | Directories containing `.ado` files to instrument |
+| `omit` | list | `[]` | Patterns to exclude from coverage |
+
+### Reporting
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `junit_xml` | string | `null` | Path for JUnit XML output |
+| `lcov` | string | `null` | Path for LCOV coverage output |
+
+## Auto-Detection
+
+statatest automatically detects the Stata executable:
+
+1. Checks `stata_executable` in config
+2. Looks for `stata-mp`, `stata-se`, `stata` in PATH
+3. Checks common installation paths
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `STATA_PATH` | Override Stata executable path |
+| `STATATEST_CONFIG` | Path to config file (default: `statatest.toml`) |
+
+## Example Configurations
+
+### Minimal
+
+```toml
+[tool.statatest]
+testpaths = ["tests"]
+```
+
+### Full Project
+
+```toml
+[tool.statatest]
+testpaths = ["tests/unit", "tests/integration"]
+test_files = ["test_*.do"]
+stata_executable = "/usr/local/bin/stata-mp"
+
+[tool.statatest.coverage]
+source = ["code/functions", "code/lib"]
+omit = ["tests/*", "examples/*"]
+
+[tool.statatest.reporting]
+junit_xml = "junit.xml"
+lcov = "coverage.lcov"
+```
+
+### CI Environment
+
+```toml
+[tool.statatest]
+testpaths = ["tests"]
+stata_executable = "stata-mp"
+
+[tool.statatest.coverage]
+source = ["src"]
+
+[tool.statatest.reporting]
+junit_xml = "results/junit.xml"
+lcov = "results/coverage.lcov"
+```

--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -1,0 +1,99 @@
+# Code Coverage
+
+statatest provides line-level code coverage for Stata `.ado` files.
+
+## How It Works
+
+Coverage is collected using invisible SMCL comment markers:
+
+1. Source files are copied to `.statatest/instrumented/`
+2. SMCL markers are injected: `{* COV:filename:lineno }`
+3. Tests run with instrumented files
+4. Markers are extracted from SMCL logs
+5. Reports are generated with original file paths
+
+The markers are invisible in Stata's output but preserved in raw `.smcl` logs.
+
+## Enable Coverage
+
+```bash
+statatest tests/ --coverage
+```
+
+## Coverage Reports
+
+### LCOV Format (for Codecov)
+
+```bash
+statatest tests/ --coverage --cov-report=lcov
+```
+
+Creates `coverage.lcov` in LCOV format:
+
+```
+TN:statatest
+SF:myfunction.ado
+DA:5,1
+DA:6,1
+DA:10,0
+LF:3
+LH:2
+end_of_record
+```
+
+### HTML Report
+
+```bash
+statatest tests/ --coverage --cov-report=html
+```
+
+Creates `htmlcov/index.html` with a visual coverage report.
+
+## Configuration
+
+Configure coverage in `statatest.toml`:
+
+```toml
+[tool.statatest.coverage]
+# Source directories to instrument
+source = ["code/functions"]
+
+# Files/patterns to exclude
+omit = ["tests/*", "*_test.ado"]
+```
+
+## Viewing Coverage
+
+### Console Output
+
+```
+============================================================
+Coverage: 85.3%
+  myfunction.ado: 90% (18/20 lines)
+  helper.ado: 75% (15/20 lines)
+============================================================
+```
+
+### HTML Report
+
+Open `htmlcov/index.html` in a browser for detailed line-by-line coverage.
+
+## Codecov Integration
+
+Upload LCOV to Codecov for PR comments:
+
+```yaml
+# .github/workflows/tests.yml
+- run: statatest tests/ --coverage --cov-report=lcov
+- uses: codecov/codecov-action@v5
+  with:
+    files: coverage.lcov
+```
+
+See [Codecov Integration](../ci/codecov.md) for details.
+
+## Limitations
+
+- Coverage requires Stata to run with SMCL logging (`-s` flag)
+- Only `.ado` files are instrumented (not `.do` files)
+- Branch coverage is not yet supported (line coverage only)

--- a/docs/guide/fixtures.md
+++ b/docs/guide/fixtures.md
@@ -1,0 +1,127 @@
+# Fixtures
+
+Fixtures provide reusable setup and teardown for tests, inspired by pytest.
+
+## Basic Fixture
+
+Define a fixture in `conftest.do`:
+
+```stata
+// tests/conftest.do
+
+program define fixture_sample_panel
+    clear
+    set obs 100
+    gen int firm_id = ceil(_n / 10)
+    gen int year = 2010 + mod(_n, 10)
+    gen double revenue = exp(rnormal(15, 2))
+end
+
+program define fixture_sample_panel_teardown
+    clear
+end
+```
+
+## Using Fixtures
+
+Use fixtures in your tests:
+
+```stata
+// tests/test_analysis.do
+// @uses_fixture: sample_panel
+
+program define test_panel_structure
+    use_fixture sample_panel
+
+    assert_obs_count 100
+    assert_var_exists firm_id
+    assert_var_exists year
+end
+```
+
+## Built-in Fixtures
+
+statatest includes several built-in fixtures:
+
+### fixture_tempfile
+
+Creates a temporary file path.
+
+```stata
+use_fixture tempfile
+
+save "$fixture_tempfile_path", replace
+```
+
+### fixture_empty_dataset
+
+Creates an empty dataset with optional observations.
+
+```stata
+// Empty dataset
+fixture_empty_dataset
+
+// With 100 observations
+fixture_empty_dataset, obs(100)
+```
+
+### fixture_seed
+
+Sets a reproducible random seed.
+
+```stata
+// Default seed (12345)
+fixture_seed
+
+// Custom seed
+fixture_seed, seed(42)
+```
+
+## Fixture Scopes
+
+Fixtures support three scopes:
+
+- **function** (default): Setup/teardown per test
+- **module**: Setup once per test file
+- **session**: Setup once per test run
+
+```stata
+use_fixture sample_panel, scope(module)
+```
+
+## Automatic Discovery
+
+statatest automatically discovers `conftest.do` files:
+
+```
+tests/
+├── conftest.do          # Root fixtures
+├── unit/
+│   ├── conftest.do      # Unit test fixtures
+│   └── test_*.do
+└── integration/
+    ├── conftest.do      # Integration test fixtures
+    └── test_*.do
+```
+
+Fixtures are loaded from root to leaf, so child directories can override parent
+fixtures.
+
+## Teardown
+
+Define a teardown function with the `_teardown` suffix:
+
+```stata
+program define fixture_database
+    // Setup: create temp database
+    use "template.dta", clear
+    save "$tempdb", replace
+end
+
+program define fixture_database_teardown
+    // Cleanup: remove temp database
+    capture erase "$tempdb"
+end
+```
+
+Teardown is called automatically when the fixture scope ends.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,66 @@
+# statatest
+
+**Pytest-inspired testing and coverage framework for Stata.**
+
+[![PyPI version](https://img.shields.io/pypi/v/statatest.svg)](https://pypi.org/project/statatest/)
+[![Python versions](https://img.shields.io/pypi/pyversions/statatest.svg)](https://pypi.org/project/statatest/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Tests](https://github.com/jigonr/statatest/actions/workflows/ci.yml/badge.svg)](https://github.com/jigonr/statatest/actions/workflows/ci.yml)
+
+## Features
+
+- **Test Discovery**: Automatically find and run `test_*.do` files
+- **Rich Assertions**: Built on Stata's native `assert` with detailed failure
+  messages
+- **Fixture System**: Reusable setup/teardown with pytest-like `conftest.do`
+  pattern
+- **Code Coverage**: Line-level coverage via SMCL comment instrumentation
+- **CI Integration**: JUnit XML output for GitHub Actions, LCOV for Codecov
+- **Backward Compatible**: Works with existing test patterns
+
+## Quick Start
+
+```bash
+# Install
+pip install statatest
+
+# Run tests
+statatest tests/
+
+# Run with coverage
+statatest tests/ --coverage --cov-report=lcov
+```
+
+## Example Test
+
+```stata
+// tests/test_myfunction.do
+
+// @marker: unit
+program define test_basic_functionality
+    clear
+    set obs 10
+    gen x = _n
+
+    myfunction x, gen(y)
+
+    assert_var_exists y
+    assert_equal _N, expected(10)
+end
+```
+
+## Requirements
+
+- **Python**: 3.11+
+- **Stata**: 16+
+
+## Getting Started
+
+1. [Installation](getting-started/installation.md)
+2. [Quick Start](getting-started/quickstart.md)
+3. [Writing Your First Test](getting-started/first-test.md)
+
+## License
+
+MIT License - see [LICENSE](https://github.com/jigonr/statatest/blob/main/LICENSE)
+for details.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,250 @@
+# Migration Guide
+
+Migrate existing Stata test patterns to statatest.
+
+## From Manual Testing
+
+### Before
+
+```stata
+// test_analysis.do
+clear all
+
+// Test 1: Check data loading
+use "data/sample.dta", clear
+local test_pass = 1
+if _N != 100 {
+    display as error "FAIL: Expected 100 observations"
+    local test_pass = 0
+}
+if "`test_pass'" == "1" {
+    display as result "PASS: Data loading"
+}
+
+// Test 2: Check variable exists
+capture confirm variable revenue
+if _rc != 0 {
+    display as error "FAIL: revenue variable missing"
+}
+```
+
+### After
+
+```stata
+// tests/test_analysis.do
+// @marker: unit
+
+clear all
+
+program define test_data_loading
+    use "data/sample.dta", clear
+    assert_obs_count 100
+end
+
+program define test_variable_exists
+    use "data/sample.dta", clear
+    assert_var_exists revenue
+end
+
+test_data_loading
+test_variable_exists
+
+display "All tests passed!"
+```
+
+## From Perfect Match Pattern
+
+### Before (30+ lines per test)
+
+```stata
+// tests/unit/test_configure_region.do
+local tests_run = 0
+local tests_passed = 0
+local tests_failed = 0
+local all_test_results ""
+
+// Test 1: EU region configuration
+local tests_run = `tests_run' + 1
+configure_region EU
+local test_pass = 1
+if "`r(region)'" != "EU" {
+    display as error "  FAIL: r(region) = `r(region)', expected EU"
+    local test_pass = 0
+}
+if "`r(deflator)'" != "IIPI" {
+    display as error "  FAIL: r(deflator) = `r(deflator)', expected IIPI"
+    local test_pass = 0
+}
+if `test_pass' == 1 {
+    local tests_passed = `tests_passed' + 1
+    local all_test_results "`all_test_results'P"
+    display as result "  PASS"
+}
+else {
+    local tests_failed = `tests_failed' + 1
+    local all_test_results "`all_test_results'F"
+}
+```
+
+### After (3-5 lines per test)
+
+```stata
+// tests/unit/test_configure_region.do
+// @marker: unit
+
+clear all
+
+program define test_eu_region
+    configure_region EU
+    assert_equal "`r(region)'", expected("EU")
+    assert_equal "`r(deflator)'", expected("IIPI")
+end
+
+program define test_gb_region
+    configure_region GB
+    assert_equal "`r(region)'", expected("GB")
+    assert_equal "`r(deflator)'", expected("IIPI")
+end
+
+test_eu_region
+test_gb_region
+
+display "All tests passed!"
+```
+
+## Key Changes
+
+### 1. Use Assertions
+
+Replace manual checks with assertions:
+
+| Before | After |
+|--------|-------|
+| `if _N != 100 { ... }` | `assert_obs_count 100` |
+| `capture confirm variable x` | `assert_var_exists x` |
+| `if r(mean) != 0.5 { ... }` | `assert_equal "`r(mean)'"`, expected("0.5")` |
+| `if abs(r(mean) - 0.5) > 0.01 { ... }` | `assert_approx_equal r(mean), expected(0.5) tol(0.01)` |
+
+### 2. Use Fixtures
+
+Replace repeated setup with fixtures:
+
+```stata
+// tests/conftest.do
+program define fixture_sample_panel
+    clear
+    set obs 100
+    gen int firm_id = ceil(_n / 10)
+    gen int year = 2010 + mod(_n, 10)
+    gen double revenue = exp(rnormal(15, 2))
+end
+```
+
+```stata
+// tests/test_analysis.do
+// @uses_fixture: sample_panel
+
+program define test_panel_structure
+    use_fixture sample_panel
+    assert_obs_count 100
+    assert_var_exists firm_id
+end
+```
+
+### 3. Use Markers
+
+Replace file organization with markers:
+
+```stata
+// @marker: unit
+// @marker: slow
+// @marker: integration
+```
+
+Run specific markers:
+
+```bash
+statatest tests/ -m "unit"
+statatest tests/ -m "not slow"
+```
+
+### 4. Run from CLI
+
+Replace manual execution:
+
+```bash
+# Before
+stata-mp -b do tests/run_all_tests.do
+
+# After
+statatest tests/
+```
+
+## Migration Steps
+
+### Step 1: Install statatest
+
+```bash
+pip install statatest
+```
+
+### Step 2: Create Configuration
+
+```bash
+statatest --init
+```
+
+### Step 3: Convert Test Files
+
+1. Keep test file naming (`test_*.do`)
+2. Replace manual checks with assertions
+3. Add markers for organization
+4. Extract common setup to fixtures
+
+### Step 4: Create conftest.do
+
+```stata
+// tests/conftest.do
+program define fixture_sample_data
+    clear
+    // Common setup code
+end
+```
+
+### Step 5: Run Tests
+
+```bash
+statatest tests/ --verbose
+```
+
+### Step 6: Add Coverage
+
+```bash
+statatest tests/ --coverage --cov-report=lcov
+```
+
+### Step 7: Update CI
+
+```yaml
+# .github/workflows/tests.yml
+- run: pip install statatest
+- run: statatest tests/ --junit-xml=junit.xml --coverage --cov-report=lcov
+```
+
+## Compatibility
+
+statatest maintains backward compatibility:
+
+- Tests without assertions still work (pass if no error)
+- Existing test file structure preserved
+- Manual counting still possible alongside assertions
+
+## Gradual Migration
+
+Migrate incrementally:
+
+1. Start with `statatest` CLI (no code changes)
+2. Add assertions to new tests
+3. Migrate existing tests file by file
+4. Add fixtures as patterns emerge
+5. Enable coverage

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,190 @@
+# CLI Reference
+
+Complete command-line interface reference for statatest.
+
+## Usage
+
+```bash
+statatest [OPTIONS] [PATH]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `PATH` | Test directory or file (default: `tests/`) |
+
+## Options
+
+### General
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--help` | `-h` | Show help message |
+| `--version` | `-V` | Show version |
+| `--verbose` | `-v` | Verbose output |
+| `--quiet` | `-q` | Minimal output |
+
+### Test Selection
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--keyword` | `-k` | Filter tests by keyword |
+| `--marker` | `-m` | Filter tests by marker |
+
+### Coverage
+
+| Option | Description |
+|--------|-------------|
+| `--coverage` | Enable coverage collection |
+| `--cov-report=TYPE` | Coverage report type: `lcov`, `html`, `term` |
+| `--cov-fail-under=N` | Fail if coverage below N% |
+
+### Reporting
+
+| Option | Description |
+|--------|-------------|
+| `--junit-xml=PATH` | Generate JUnit XML report |
+
+### Configuration
+
+| Option | Description |
+|--------|-------------|
+| `--init` | Create default configuration file |
+| `--config=PATH` | Specify config file path |
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Run all tests
+statatest tests/
+
+# Run specific file
+statatest tests/test_myfunction.do
+
+# Run with verbose output
+statatest --verbose tests/
+```
+
+### Filtering Tests
+
+```bash
+# Filter by keyword
+statatest tests/ -k "regression"
+
+# Filter by marker
+statatest tests/ -m "unit"
+
+# Exclude markers
+statatest tests/ -m "not slow"
+
+# Combine filters
+statatest tests/ -k "regression" -m "unit"
+```
+
+### Coverage
+
+```bash
+# Enable coverage
+statatest tests/ --coverage
+
+# Generate LCOV report
+statatest tests/ --coverage --cov-report=lcov
+
+# Generate HTML report
+statatest tests/ --coverage --cov-report=html
+
+# Fail if coverage below threshold
+statatest tests/ --coverage --cov-fail-under=80
+```
+
+### CI Integration
+
+```bash
+# Full CI command
+statatest tests/ \
+  --verbose \
+  --coverage \
+  --cov-report=lcov \
+  --junit-xml=junit.xml
+```
+
+### Configuration
+
+```bash
+# Create config file
+statatest --init
+
+# Use specific config
+statatest tests/ --config=myconfig.toml
+```
+
+## Exit Codes
+
+| Code | Description |
+|------|-------------|
+| 0 | All tests passed |
+| 1 | Some tests failed |
+| 2 | Configuration error |
+| 3 | No tests found |
+| 4 | Coverage below threshold |
+
+## Output Formats
+
+### Default
+
+```
+statatest v0.1.0
+Collecting tests from: tests
+Found 5 test file(s)
+
+.....
+
+============================================================
+5 passed in 2.34s
+```
+
+### Verbose
+
+```
+statatest v0.1.0
+Collecting tests from: tests
+Found 5 test file(s)
+
+Running: tests/test_equal.do PASSED (0.25s)
+Running: tests/test_true.do PASSED (0.18s)
+Running: tests/test_false.do PASSED (0.22s)
+Running: tests/test_var.do PASSED (0.31s)
+Running: tests/test_file.do PASSED (0.28s)
+
+============================================================
+5 passed in 2.34s
+```
+
+### With Coverage
+
+```
+statatest v0.1.0
+Collecting tests from: tests
+Found 5 test file(s)
+
+.....
+
+============================================================
+5 passed in 2.34s
+============================================================
+Coverage: 85.3%
+  myfunction.ado: 90% (18/20 lines)
+  helper.ado: 75% (15/20 lines)
+============================================================
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `STATA_PATH` | Override Stata executable |
+| `STATATEST_CONFIG` | Config file path |
+| `NO_COLOR` | Disable colored output |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,0 +1,219 @@
+# Configuration Reference
+
+Complete reference for `statatest.toml` configuration options.
+
+## File Location
+
+statatest looks for configuration in:
+
+1. `statatest.toml` in current directory
+2. `pyproject.toml` under `[tool.statatest]`
+3. Path specified by `--config` option
+4. Path specified by `STATATEST_CONFIG` environment variable
+
+## Schema
+
+```toml
+[tool.statatest]
+# Test discovery
+testpaths = ["tests"]
+test_files = ["test_*.do"]
+stata_executable = "stata-mp"
+
+[tool.statatest.coverage]
+source = ["code/functions"]
+omit = ["tests/*"]
+
+[tool.statatest.reporting]
+junit_xml = "junit.xml"
+lcov = "coverage.lcov"
+```
+
+## Options Reference
+
+### `[tool.statatest]`
+
+#### `testpaths`
+
+Directories to search for test files.
+
+- **Type:** `list[str]`
+- **Default:** `["tests"]`
+
+```toml
+testpaths = ["tests/unit", "tests/integration"]
+```
+
+#### `test_files`
+
+Glob patterns for test file discovery.
+
+- **Type:** `list[str]`
+- **Default:** `["test_*.do"]`
+
+```toml
+test_files = ["test_*.do", "*_test.do"]
+```
+
+#### `stata_executable`
+
+Path to Stata executable.
+
+- **Type:** `str`
+- **Default:** Auto-detected
+
+```toml
+stata_executable = "/usr/local/bin/stata-mp"
+```
+
+Auto-detection order:
+
+1. `stata-mp`
+2. `stata-se`
+3. `stata`
+4. Common installation paths
+
+### `[tool.statatest.coverage]`
+
+#### `source`
+
+Directories containing `.ado` files to instrument.
+
+- **Type:** `list[str]`
+- **Default:** `[]`
+
+```toml
+[tool.statatest.coverage]
+source = ["code/functions", "code/lib"]
+```
+
+#### `omit`
+
+Patterns to exclude from coverage.
+
+- **Type:** `list[str]`
+- **Default:** `[]`
+
+```toml
+[tool.statatest.coverage]
+omit = ["tests/*", "*_test.ado", "examples/*"]
+```
+
+### `[tool.statatest.reporting]`
+
+#### `junit_xml`
+
+Path for JUnit XML test results.
+
+- **Type:** `str | null`
+- **Default:** `null`
+
+```toml
+[tool.statatest.reporting]
+junit_xml = "results/junit.xml"
+```
+
+#### `lcov`
+
+Path for LCOV coverage report.
+
+- **Type:** `str | null`
+- **Default:** `null`
+
+```toml
+[tool.statatest.reporting]
+lcov = "results/coverage.lcov"
+```
+
+## Example Configurations
+
+### Minimal
+
+```toml
+[tool.statatest]
+testpaths = ["tests"]
+```
+
+### Research Project
+
+```toml
+[tool.statatest]
+testpaths = ["tests/unit", "tests/integration"]
+test_files = ["test_*.do"]
+stata_executable = "stata-mp"
+
+[tool.statatest.coverage]
+source = ["code/functions"]
+omit = ["tests/*", "examples/*"]
+
+[tool.statatest.reporting]
+junit_xml = "junit.xml"
+lcov = "coverage.lcov"
+```
+
+### Monorepo
+
+```toml
+[tool.statatest]
+testpaths = [
+  "packages/core/tests",
+  "packages/utils/tests",
+  "packages/analysis/tests"
+]
+
+[tool.statatest.coverage]
+source = [
+  "packages/core/src",
+  "packages/utils/src",
+  "packages/analysis/src"
+]
+```
+
+### CI-Optimized
+
+```toml
+[tool.statatest]
+testpaths = ["tests"]
+stata_executable = "stata-mp"
+
+[tool.statatest.reporting]
+junit_xml = "test-results/junit.xml"
+lcov = "test-results/coverage.lcov"
+```
+
+## pyproject.toml Integration
+
+Configuration can also be placed in `pyproject.toml`:
+
+```toml
+# pyproject.toml
+[project]
+name = "my-stata-project"
+version = "1.0.0"
+
+[tool.statatest]
+testpaths = ["tests"]
+
+[tool.statatest.coverage]
+source = ["code/functions"]
+```
+
+## Validation
+
+statatest validates configuration on startup:
+
+```bash
+$ statatest tests/
+Error: Invalid configuration in statatest.toml
+  - testpaths[0]: Directory 'tests' does not exist
+```
+
+## Precedence
+
+Configuration sources are merged in order (later overrides earlier):
+
+1. Built-in defaults
+2. `pyproject.toml` `[tool.statatest]`
+3. `statatest.toml`
+4. `--config` file
+5. Command-line options

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,72 @@
+site_name: statatest
+site_url: https://jigonr.github.io/statatest/
+site_description: Pytest-inspired testing and coverage framework for Stata
+site_author: Jose Ignacio Gonzalez Rojas
+
+repo_name: jigonr/statatest
+repo_url: https://github.com/jigonr/statatest
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - Quick Start: getting-started/quickstart.md
+      - First Test: getting-started/first-test.md
+  - User Guide:
+      - Assertions: guide/assertions.md
+      - Fixtures: guide/fixtures.md
+      - Coverage: guide/coverage.md
+      - Configuration: guide/configuration.md
+  - CI Integration:
+      - GitHub Actions: ci/github-actions.md
+      - Codecov: ci/codecov.md
+  - Reference:
+      - CLI: reference/cli.md
+      - Configuration: reference/config.md
+  - Migration: migration.md
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - tables
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/jigonr/statatest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0.0",
 ]
+docs = [
+    "mkdocs>=1.5.0",
+    "mkdocs-material>=9.5.0",
+    "pymdown-extensions>=10.0.0",
+]
 
 [project.scripts]
 statatest = "statatest.cli:main"


### PR DESCRIPTION
## Summary

- Add comprehensive documentation using MkDocs with Material theme
- Configure GitHub Actions workflow for automatic deployment to GitHub Pages
- Include 13 documentation pages covering all features

## Documentation Structure

**Getting Started:**
- Installation guide
- Quick start tutorial
- First test walkthrough

**User Guide:**
- Assertions reference
- Fixtures system
- Coverage collection
- Configuration options

**CI Integration:**
- GitHub Actions setup
- Codecov integration

**Reference:**
- CLI reference
- Configuration file reference

**Migration:**
- Guide for migrating from existing test patterns

## Changes

- `mkdocs.yml` - MkDocs configuration
- `docs/**/*.md` - 13 documentation pages
- `.github/workflows/docs.yml` - Documentation deployment workflow
- `README.md` - Added docs badge and links
- `pyproject.toml` - Added docs optional dependencies

## Test plan

- [x] 48 Python tests pass
- [ ] Build docs locally: `mkdocs build --strict`
- [ ] Verify docs deploy after merge

Closes #4