### PR TITLE
ci: add scheduled Stata integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Run Stata integration tests weekly on Sundays at 00:00 UTC
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+    inputs:
+      run_stata_tests:
+        description: "Run Stata integration tests"
+        required: false
+        default: "false"
+        type: boolean
 
 jobs:
   test:
@@ -63,10 +73,12 @@ jobs:
       - name: Run mypy
         run: uv run mypy src/statatest
 
-  # Integration tests with Stata (manual trigger only)
+  # Integration tests with Stata (scheduled weekly or manual trigger)
   integration:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
+    if: >
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_stata_tests == 'true')
     container:
       image: dataeditors/stata18:latest
       options: --user root
@@ -77,6 +89,11 @@ jobs:
       - name: Set up license
         run: |
           echo "${{ secrets.STATA_LIC_B64 }}" | base64 -d > /usr/local/stata/stata.lic
+
+      - name: Verify Stata installation
+        run: |
+          stata-mp -v
+          echo "Stata installation verified"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -89,12 +106,28 @@ jobs:
       - name: Install statatest
         run: uv pip install -e .
 
-      - name: Run Stata tests
-        run: statatest tests/ --junit-xml=junit.xml
+      - name: Run Stata assertion tests
+        run: |
+          statatest tests/stata/ \
+            --verbose \
+            --junit-xml=junit-stata.xml \
+            --coverage \
+            --cov-report=lcov
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results
-          path: junit.xml
+          name: stata-test-results
+          path: |
+            junit-stata.xml
+            coverage.lcov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        if: always()
+        with:
+          files: coverage.lcov
+          flags: stata
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/tests/stata/conftest.do
+++ b/tests/stata/conftest.do
@@ -1,0 +1,47 @@
+// conftest.do
+// Fixtures for Stata integration tests
+
+// ============================================================================
+// Fixture: sample_data
+// Creates a simple dataset for testing
+// ============================================================================
+
+program define fixture_sample_data
+    clear
+    set obs 100
+    gen id = _n
+    gen group = mod(_n, 4) + 1
+    gen value = rnormal(50, 10)
+    gen str10 category = cond(group <= 2, "A", "B")
+end
+
+program define fixture_sample_data_teardown
+    clear
+end
+
+// ============================================================================
+// Fixture: panel_data
+// Creates a simple panel dataset
+// ============================================================================
+
+program define fixture_panel_data
+    clear
+    set obs 200
+    gen id = ceil(_n / 10)
+    gen year = 2010 + mod(_n - 1, 10)
+    gen value = rnormal(100, 20)
+    xtset id year
+end
+
+program define fixture_panel_data_teardown
+    clear
+end
+
+// ============================================================================
+// Fixture: deterministic_seed
+// Sets a reproducible random seed
+// ============================================================================
+
+program define fixture_deterministic_seed
+    set seed 12345
+end

--- a/tests/stata/test_assertions.do
+++ b/tests/stata/test_assertions.do
@@ -1,0 +1,182 @@
+// test_assertions.do
+// Tests for statatest assertion functions
+// @marker: unit
+
+clear all
+
+// ============================================================================
+// Test assert_equal
+// ============================================================================
+
+program define test_assert_equal_string
+    local result = "success"
+    assert_equal "`result'", expected("success")
+end
+
+program define test_assert_equal_numeric
+    local value = 42
+    assert_equal `value', expected(42)
+end
+
+program define test_assert_equal_with_message
+    local status = "active"
+    assert_equal "`status'", expected("active") message("Status should be active")
+end
+
+// ============================================================================
+// Test assert_true and assert_false
+// ============================================================================
+
+program define test_assert_true_basic
+    assert_true 1 == 1
+    assert_true 5 > 3
+    assert_true 10 >= 10
+end
+
+program define test_assert_false_basic
+    assert_false 1 == 0
+    assert_false 3 > 5
+    assert_false 1 > 10
+end
+
+// ============================================================================
+// Test assert_var_exists
+// ============================================================================
+
+program define test_assert_var_exists_basic
+    clear
+    set obs 10
+    gen x = _n
+    gen str10 name = "test"
+    
+    assert_var_exists x
+    assert_var_exists name
+end
+
+// ============================================================================
+// Test assert_obs_count
+// ============================================================================
+
+program define test_assert_obs_count_basic
+    clear
+    set obs 100
+    gen x = _n
+    
+    assert_obs_count 100
+end
+
+program define test_assert_obs_count_with_if
+    clear
+    set obs 100
+    gen x = _n
+    gen group = mod(_n, 2)
+    
+    assert_obs_count 50 if group == 0
+    assert_obs_count 50 if group == 1
+end
+
+// ============================================================================
+// Test assert_approx_equal
+// ============================================================================
+
+program define test_assert_approx_equal_basic
+    local pi = 3.14159
+    assert_approx_equal `pi', expected(3.14) tol(0.01)
+end
+
+program define test_assert_approx_equal_regression
+    clear
+    set seed 12345
+    set obs 100
+    gen x = rnormal()
+    gen y = 2*x + rnormal()
+    
+    regress y x
+    
+    // Coefficient should be approximately 2
+    assert_approx_equal _b[x], expected(2) tol(0.5)
+end
+
+// ============================================================================
+// Test assert_in_range
+// ============================================================================
+
+program define test_assert_in_range_basic
+    local value = 50
+    assert_in_range `value', min(0) max(100)
+end
+
+program define test_assert_in_range_r2
+    clear
+    set seed 12345
+    set obs 100
+    gen x = rnormal()
+    gen y = 2*x + rnormal()
+    
+    regress y x
+    
+    // R-squared should be between 0 and 1
+    assert_in_range e(r2), min(0) max(1)
+end
+
+// ============================================================================
+// Test assert_error and assert_noerror
+// ============================================================================
+
+program define test_assert_error_basic
+    // This command should fail (dropping non-existent variable)
+    assert_error "drop nonexistent_variable_xyz"
+end
+
+program define test_assert_noerror_basic
+    clear
+    set obs 10
+    gen x = _n
+    
+    // This command should succeed
+    assert_noerror "summarize x"
+end
+
+// ============================================================================
+// Test assert_file_exists
+// ============================================================================
+
+program define test_assert_file_exists_temp
+    tempfile tf
+    
+    clear
+    set obs 10
+    gen x = _n
+    save "`tf'", replace
+    
+    assert_file_exists "`tf'"
+end
+
+// ============================================================================
+// Run all tests
+// ============================================================================
+
+test_assert_equal_string
+test_assert_equal_numeric
+test_assert_equal_with_message
+
+test_assert_true_basic
+test_assert_false_basic
+
+test_assert_var_exists_basic
+
+test_assert_obs_count_basic
+test_assert_obs_count_with_if
+
+test_assert_approx_equal_basic
+test_assert_approx_equal_regression
+
+test_assert_in_range_basic
+test_assert_in_range_r2
+
+test_assert_error_basic
+test_assert_noerror_basic
+
+test_assert_file_exists_temp
+
+display as result "All assertion tests passed!"

--- a/tests/stata/test_fixtures.do
+++ b/tests/stata/test_fixtures.do
@@ -1,0 +1,71 @@
+// test_fixtures.do
+// Tests for statatest fixture system
+// @marker: unit
+// @uses_fixture: sample_data
+
+clear all
+
+// ============================================================================
+// Test fixture loading
+// ============================================================================
+
+program define test_fixture_sample_data
+    use_fixture sample_data
+    
+    assert_obs_count 100
+    assert_var_exists id
+    assert_var_exists group
+    assert_var_exists value
+    assert_var_exists category
+end
+
+program define test_fixture_deterministic
+    use_fixture deterministic_seed
+    
+    // Generate random values - should be deterministic
+    clear
+    set obs 10
+    gen x = rnormal()
+    
+    // First value should be consistent with seed 12345
+    assert_true !missing(x[1])
+end
+
+// ============================================================================
+// Test fixture with assertions
+// ============================================================================
+
+program define test_fixture_data_properties
+    use_fixture sample_data
+    
+    // Check group values
+    summarize group
+    assert_in_range r(min), min(1) max(4)
+    assert_in_range r(max), min(1) max(4)
+    
+    // Check category values
+    tab category
+    assert_true r(r) == 2  // Should have exactly 2 categories
+end
+
+program define test_panel_structure
+    use_fixture panel_data
+    
+    // Check panel structure
+    assert_obs_count 200
+    
+    // Check xtset worked
+    xtsum value
+    assert_true r(N) > 0
+end
+
+// ============================================================================
+// Run all tests
+// ============================================================================
+
+test_fixture_sample_data
+test_fixture_deterministic
+test_fixture_data_properties
+test_panel_structure
+
+display as result "All fixture tests passed!"


### PR DESCRIPTION
## Summary

Add scheduled CI workflow for running Stata integration tests with actual Stata execution.

## Changes

### Workflow Updates (.github/workflows/ci.yml)

- Add weekly schedule trigger (Sundays 00:00 UTC)
- Add `workflow_dispatch` input for manual triggers with `run_stata_tests` option
- Add Stata verification step
- Add coverage upload for Stata tests with `stata` flag
- Improve artifact naming

### New Test Files (tests/stata/)

- **conftest.do**: Fixtures for Stata tests
  - `fixture_sample_data`: Creates sample dataset (100 obs, id, group, value, category)
  - `fixture_panel_data`: Creates panel dataset (200 obs, xtset)
  - `fixture_deterministic_seed`: Sets reproducible seed

- **test_assertions.do**: Tests all 10 assertion functions
  - assert_equal (string, numeric, with message)
  - assert_true, assert_false
  - assert_var_exists
  - assert_obs_count (basic and with if condition)
  - assert_approx_equal (basic and regression)
  - assert_in_range (basic and R-squared)
  - assert_error, assert_noerror
  - assert_file_exists

- **test_fixtures.do**: Tests fixture system
  - Fixture loading
  - Data properties validation
  - Panel structure verification

## Test plan

- [x] YAML validation passes
- [x] Python linting passes
- [ ] Stata tests pass (requires manual trigger with license)

## Notes

- Requires `STATA_LIC_B64` secret with base64-encoded Stata license
- Uses `dataeditors/stata18:latest` Docker image
- Runs weekly or on manual dispatch with `run_stata_tests: true`

Closes #7

🤖 Generated with [Letta Code](https://letta.com)