### PR TITLE
fix(econ): correct network terminology and add AKM bipartite fixture

### DIFF
--- a/src/statatest/ado/econ/fixtures/fixture_production_network.ado
+++ b/src/statatest/ado/econ/fixtures/fixture_production_network.ado
@@ -1,0 +1,110 @@
+*! fixture_production_network.ado
+*! Version 1.0.0
+*! Creates a sparse directed weighted production network for testing
+*! Based on Bernard & Zi (2022) elementary model
+*!
+*! Syntax:
+*!   fixture_production_network [, n_firms(#) n_edges(#) temporal seed(#)]
+*!
+*! Options:
+*!   n_firms(#)  - Total number of firms (default: 100)
+*!   n_edges(#)  - Number of edges/transactions (default: 500)
+*!   temporal    - Add year dimension (2015-2019)
+*!   seed(#)     - Random seed (default: 12345)
+*!
+*! Creates variables:
+*!   seller  - Seller firm ID (source node)
+*!   buyer   - Buyer firm ID (target node)
+*!   weight  - Transaction value (log-normal)
+*!   year    - Time period (if temporal option specified)
+*!
+*! Network properties (Bernard & Zi 2022):
+*!   - Directed: seller → buyer
+*!   - Weighted: transaction values
+*!   - Sparse: not fully connected
+*!   - NOT bipartite: firms can be both buyers and sellers
+*!   - ~31% only buyers, ~13% only sellers, ~56% both
+
+program define fixture_production_network
+    version 16
+    
+    syntax [, n_firms(integer 100) n_edges(integer 500) temporal seed(integer 12345)]
+    
+    clear
+    set seed `seed'
+    
+    // Firm composition (Bernard & Zi 2022 calibration)
+    // These shares come from Costa Rican production network data
+    local n_only_buyers = floor(0.31 * `n_firms')
+    local n_only_sellers = floor(0.13 * `n_firms')
+    local n_both = `n_firms' - `n_only_buyers' - `n_only_sellers'
+    
+    // Seller pool: only_sellers + both
+    local n_sellers = `n_only_sellers' + `n_both'
+    // Buyer pool: only_buyers + both  
+    local n_buyers = `n_only_buyers' + `n_both'
+    
+    // Create edges
+    if "`temporal'" != "" {
+        local n_years = 5
+        local total_edges = `n_edges' * `n_years'
+    }
+    else {
+        local total_edges = `n_edges'
+    }
+    
+    set obs `total_edges'
+    
+    // Generate seller IDs (from seller pool)
+    gen int seller = ceil(runiform() * `n_sellers')
+    
+    // Generate buyer IDs (from buyer pool, offset by n_only_sellers)
+    // This allows overlap: firms in "both" category can buy from each other
+    gen int buyer = `n_only_sellers' + ceil(runiform() * `n_buyers')
+    
+    // Allow self-loops to be removed (firm buying from itself is rare but possible)
+    // In production networks, self-loops are usually excluded
+    drop if seller == buyer
+    
+    // Transaction weight (log-normal, following BCCR data moments)
+    // Mean ~0.034, calibrated to Costa Rican transaction data
+    gen double weight = exp(rnormal(-3.4, 0.5))
+    
+    // Add temporal dimension if requested
+    if "`temporal'" != "" {
+        gen int year = 2015 + floor((_n - 1) / `n_edges')
+        label variable year "Transaction year"
+    }
+    
+    // Remove exact duplicates (keep unique edges per period)
+    // In production networks, multiple transactions between same pair
+    // are typically aggregated
+    if "`temporal'" != "" {
+        duplicates drop seller buyer year, force
+    }
+    else {
+        duplicates drop seller buyer, force
+    }
+    
+    // Labels
+    label variable seller "Seller firm ID (source)"
+    label variable buyer "Buyer firm ID (target)"
+    label variable weight "Transaction value"
+    
+    // Return info
+    quietly count
+    return scalar n_edges = r(N)
+    return scalar n_firms = `n_firms'
+    return scalar n_sellers = `n_sellers'
+    return scalar n_buyers = `n_buyers'
+end
+
+// Alias for trade network (same structure, different domain)
+program define fixture_trade_network
+    fixture_production_network `0'
+end
+
+// Alias for supply chain
+program define fixture_supply_chain
+    fixture_production_network `0'
+end


### PR DESCRIPTION
## Summary

Fix network terminology and add proper bipartite fixture following AKM structure.

## Breaking Change

Renamed `fixture_bipartite_network` → `fixture_production_network` for Bernard & Zi (2022) structure.

## Network Types (Corrected)

### Production Network (Bernard & Zi 2022)
- **Structure**: Sparse, directed, weighted
- **Node types**: Firm → Firm (same type)
- **NOT bipartite**: Firms can be both buyers and sellers
- **Fixture**: `fixture_production_network`
- **Aliases**: `fixture_trade_network`, `fixture_supply_chain`

### Bipartite Network (AKM-style)
- **Structure**: Two distinct node types
- **Node types**: Workers ↔ Firms (different types)
- **Bipartite**: Edges only between types
- **Follows**: Abowd-Kramarz-Margolis (1999) wage decomposition
- **Fixture**: `fixture_bipartite_network`
- **Aliases**: `fixture_employer_employee`, `fixture_matched_panel`
- **Creates**: worker_id, firm_id, year, wage

## AKM Structure

```
log(wage) = worker_effect + firm_effect + experience + residual
```

- Worker effects: N(0, 0.3) - permanent worker ability
- Firm effects: N(0, 0.2) - firm wage premium
- Mobility parameter: ~15% job switching per year

## Test plan

- [x] Correct terminology applied
- [x] Production network maintains Bernard & Zi calibration
- [x] Bipartite network follows AKM structure
- [ ] Documentation update (future PR)

🤖 Generated with [Letta Code](https://letta.com)