### PR TITLE
feat(econ): add panel fixtures and economic assertions

### DIFF
--- a/src/statatest/ado/econ/assertions/assert_identity.ado
+++ b/src/statatest/ado/econ/assertions/assert_identity.ado
@@ -1,0 +1,83 @@
+*! assert_identity.ado
+*! Version 1.0.0
+*! Assert that an accounting identity holds (row-wise equality)
+*!
+*! Syntax:
+*!   assert_identity exp1 == exp2 [if] [, tol(#) message(string)]
+*!
+*! Options:
+*!   tol(#)        - Tolerance for numeric comparison (default: 1e-10)
+*!   message(str)  - Custom error message
+*!
+*! Examples:
+*!   assert_identity assets == liabilities + equity
+*!   assert_identity fob + freight + insurance == cif, tol(0.01)
+*!   assert_identity revenue - costs == profit if year == 2020
+
+program define assert_identity
+    version 16
+    
+    // Parse the equality expression
+    gettoken lhs rest : 0, parse("==")
+    gettoken eq rest : rest, parse("==")
+    
+    if "`eq'" != "==" {
+        display as error "Syntax: assert_identity exp1 == exp2 [if] [, options]"
+        exit 198
+    }
+    
+    // Parse RHS and options
+    local 0 `rest'
+    syntax anything [if] [, tol(real 1e-10) message(string)]
+    local rhs `anything'
+    
+    marksample touse, novarlist
+    
+    // Calculate both sides
+    tempvar lhs_val rhs_val diff
+    
+    capture gen double `lhs_val' = `lhs' if `touse'
+    if _rc != 0 {
+        display as error "Error evaluating LHS expression: `lhs'"
+        exit _rc
+    }
+    
+    capture gen double `rhs_val' = `rhs' if `touse'
+    if _rc != 0 {
+        display as error "Error evaluating RHS expression: `rhs'"
+        exit _rc
+    }
+    
+    gen double `diff' = abs(`lhs_val' - `rhs_val')
+    
+    // Count violations
+    quietly count if `diff' > `tol' & `touse' & !missing(`diff')
+    local n_fail = r(N)
+    
+    if `n_fail' > 0 {
+        display as error ""
+        display as error "ASSERTION FAILED: assert_identity"
+        display as error "  Identity: `lhs' == `rhs'"
+        display as error "  Tolerance: `tol'"
+        display as error "  `n_fail' observations violate the identity"
+        if "`message'" != "" {
+            display as error "  Message: `message'"
+        }
+        
+        // Show summary of differences
+        display as error ""
+        display as error "  Summary of differences:"
+        summarize `diff' if `diff' > `tol' & `touse', detail
+        
+        // Show first few violations
+        display as error ""
+        display as error "  First 5 violations:"
+        gen double _lhs = `lhs_val'
+        gen double _rhs = `rhs_val'
+        gen double _diff = `diff'
+        list _lhs _rhs _diff if `diff' > `tol' & `touse' in 1/5, noobs
+        drop _lhs _rhs _diff
+        
+        exit 9
+    }
+end

--- a/src/statatest/ado/econ/assertions/assert_panel_structure.ado
+++ b/src/statatest/ado/econ/assertions/assert_panel_structure.ado
@@ -1,0 +1,111 @@
+*! assert_panel_structure.ado
+*! Version 1.0.0
+*! Assert that data has valid panel structure (xtset)
+*!
+*! Syntax:
+*!   assert_panel_structure [panelvar timevar] [, balanced message(string)]
+*!
+*! Options:
+*!   balanced      - Require balanced panel (all units have all periods)
+*!   message(str)  - Custom error message
+*!
+*! If panelvar and timevar not specified, checks current xtset.
+*!
+*! Examples:
+*!   assert_panel_structure                    // Check current xtset
+*!   assert_panel_structure id year            // Check specific variables
+*!   assert_panel_structure id year, balanced  // Require balanced panel
+
+program define assert_panel_structure
+    version 16
+    
+    syntax [varlist(min=0 max=2)] [, balanced message(string)]
+    
+    local nvars : word count `varlist'
+    
+    if `nvars' == 0 {
+        // Check current xtset
+        capture xtset
+        if _rc != 0 {
+            display as error ""
+            display as error "ASSERTION FAILED: assert_panel_structure"
+            display as error "  Data is not xtset"
+            if "`message'" != "" {
+                display as error "  Message: `message'"
+            }
+            exit 9
+        }
+        local panelvar = r(panelvar)
+        local timevar = r(timevar)
+    }
+    else if `nvars' == 1 {
+        display as error "Must specify both panelvar and timevar, or neither"
+        exit 198
+    }
+    else {
+        local panelvar : word 1 of `varlist'
+        local timevar : word 2 of `varlist'
+        
+        // Try to xtset with these variables
+        capture xtset `panelvar' `timevar'
+        if _rc != 0 {
+            display as error ""
+            display as error "ASSERTION FAILED: assert_panel_structure"
+            display as error "  Cannot xtset with: `panelvar' `timevar'"
+            display as error "  Error code: `=_rc'"
+            if "`message'" != "" {
+                display as error "  Message: `message'"
+            }
+            exit 9
+        }
+    }
+    
+    // Check for uniqueness using gisid if available
+    capture which gisid
+    if _rc == 0 {
+        capture gisid `panelvar' `timevar'
+    }
+    else {
+        capture isid `panelvar' `timevar'
+    }
+    
+    if _rc != 0 {
+        display as error ""
+        display as error "ASSERTION FAILED: assert_panel_structure"
+        display as error "  Panel variables: `panelvar' `timevar'"
+        display as error "  Not uniquely identified (duplicates exist)"
+        if "`message'" != "" {
+            display as error "  Message: `message'"
+        }
+        exit 9
+    }
+    
+    // Check for balanced panel if requested
+    if "`balanced'" != "" {
+        quietly xtset
+        local panel_id = r(panelvar)
+        local time_id = r(timevar)
+        
+        // Count observations per panel unit
+        tempvar n_periods_per_unit
+        bysort `panel_id': gen `n_periods_per_unit' = _N
+        
+        // Get expected number of periods
+        quietly summarize `time_id'
+        local expected_periods = r(max) - r(min) + 1
+        
+        // Check if all units have same number of periods
+        quietly summarize `n_periods_per_unit'
+        if r(min) != r(max) | r(min) != `expected_periods' {
+            display as error ""
+            display as error "ASSERTION FAILED: assert_panel_structure"
+            display as error "  Panel is NOT balanced"
+            display as error "  Expected periods per unit: `expected_periods'"
+            display as error "  Actual range: `=r(min)' to `=r(max)'"
+            if "`message'" != "" {
+                display as error "  Message: `message'"
+            }
+            exit 9
+        }
+    }
+end

--- a/src/statatest/ado/econ/assertions/assert_positive.ado
+++ b/src/statatest/ado/econ/assertions/assert_positive.ado
@@ -1,0 +1,70 @@
+*! assert_positive.ado
+*! Version 1.0.0
+*! Assert that all values of a variable are positive
+*!
+*! Syntax:
+*!   assert_positive varname [if] [, strict message(string)]
+*!
+*! Options:
+*!   strict        - Require strictly positive (> 0), not just non-negative
+*!   message(str)  - Custom error message
+*!
+*! Examples:
+*!   assert_positive sales
+*!   assert_positive wage, strict message("Wages must be positive")
+*!   assert_positive revenue if year >= 2015
+
+program define assert_positive
+    version 16
+    
+    syntax varname [if] [, strict message(string)]
+    
+    marksample touse
+    
+    // Check for missing values first
+    quietly count if missing(`varlist') & `touse'
+    if r(N) > 0 {
+        display as error ""
+        display as error "ASSERTION FAILED: assert_positive"
+        display as error "  Variable: `varlist'"
+        display as error "  Found `r(N)' missing values"
+        if "`message'" != "" {
+            display as error "  Message: `message'"
+        }
+        exit 9
+    }
+    
+    // Check for non-positive values
+    if "`strict'" != "" {
+        // Strictly positive: > 0
+        quietly count if `varlist' <= 0 & `touse'
+        local condition "<= 0"
+    }
+    else {
+        // Non-negative by default: >= 0
+        quietly count if `varlist' < 0 & `touse'
+        local condition "< 0"
+    }
+    
+    if r(N) > 0 {
+        display as error ""
+        display as error "ASSERTION FAILED: assert_positive"
+        display as error "  Variable: `varlist'"
+        display as error "  Found `r(N)' values `condition'"
+        if "`message'" != "" {
+            display as error "  Message: `message'"
+        }
+        
+        // Show summary of problematic values
+        display as error ""
+        display as error "  Summary of non-positive values:"
+        if "`strict'" != "" {
+            summarize `varlist' if `varlist' <= 0 & `touse', detail
+        }
+        else {
+            summarize `varlist' if `varlist' < 0 & `touse', detail
+        }
+        
+        exit 9
+    }
+end

--- a/src/statatest/ado/econ/assertions/assert_sorted.ado
+++ b/src/statatest/ado/econ/assertions/assert_sorted.ado
@@ -1,0 +1,60 @@
+*! assert_sorted.ado
+*! Version 1.0.0
+*! Assert that data is sorted by specified variables
+*!
+*! Syntax:
+*!   assert_sorted varlist [, message(string)]
+*!
+*! Options:
+*!   message(str)  - Custom error message
+*!
+*! Examples:
+*!   assert_sorted id year
+*!   assert_sorted firm_id year, message("Data must be sorted by firm-year")
+
+program define assert_sorted
+    version 16
+    
+    syntax varlist [, message(string)]
+    
+    // Check if data is sorted using hashsort verification if available
+    capture which hashsort
+    local use_gtools = (_rc == 0)
+    
+    // Store current sort order
+    tempvar sortcheck
+    gen long `sortcheck' = _n
+    
+    // Sort by specified variables and check if order changed
+    if `use_gtools' {
+        capture noisily hashsort `varlist', sortgen(_newsort)
+        local sorted_var "_newsort"
+    }
+    else {
+        sort `varlist'
+        gen long _newsort = _n
+        local sorted_var "_newsort"
+    }
+    
+    // Compare original order with sorted order
+    quietly count if `sortcheck' != `sorted_var'
+    local n_changed = r(N)
+    
+    // Clean up
+    capture drop _newsort
+    
+    // Restore original order
+    sort `sortcheck'
+    
+    if `n_changed' > 0 {
+        display as error ""
+        display as error "ASSERTION FAILED: assert_sorted"
+        display as error "  Variables: `varlist'"
+        display as error "  Data is NOT sorted by these variables"
+        display as error "  `n_changed' observations would change position"
+        if "`message'" != "" {
+            display as error "  Message: `message'"
+        }
+        exit 9
+    }
+end

--- a/src/statatest/ado/econ/assertions/assert_sum_equals.ado
+++ b/src/statatest/ado/econ/assertions/assert_sum_equals.ado
@@ -1,0 +1,76 @@
+*! assert_sum_equals.ado
+*! Version 1.0.0
+*! Assert that sum of a variable equals expected value
+*!
+*! Syntax:
+*!   assert_sum_equals varname [if], expected(#) [tol(#) by(varlist) message(string)]
+*!
+*! Options:
+*!   expected(#)   - Expected sum value (required)
+*!   tol(#)        - Tolerance for comparison (default: 1e-10)
+*!   by(varlist)   - Check sum within each group
+*!   message(str)  - Custom error message
+*!
+*! Examples:
+*!   assert_sum_equals share, expected(1)                  // Shares sum to 1
+*!   assert_sum_equals weight, expected(100) tol(0.01)    // Allow small error
+*!   assert_sum_equals detail, expected(total) by(group)  // By group
+
+program define assert_sum_equals
+    version 16
+    
+    syntax varname [if], expected(real) [tol(real 1e-10) by(varlist) message(string)]
+    
+    marksample touse
+    
+    if "`by'" != "" {
+        // Check sum within each group
+        tempvar group_sum group_diff
+        
+        gegen double `group_sum' = total(`varlist') if `touse', by(`by')
+        gen double `group_diff' = abs(`group_sum' - `expected')
+        
+        quietly count if `group_diff' > `tol' & `touse' & !missing(`group_diff')
+        local n_fail = r(N)
+        
+        if `n_fail' > 0 {
+            display as error ""
+            display as error "ASSERTION FAILED: assert_sum_equals"
+            display as error "  Variable: `varlist'"
+            display as error "  By groups: `by'"
+            display as error "  Expected sum: `expected'"
+            display as error "  Tolerance: `tol'"
+            display as error "  `n_fail' observations in groups with incorrect sum"
+            if "`message'" != "" {
+                display as error "  Message: `message'"
+            }
+            
+            // Show failing groups
+            display as error ""
+            display as error "  Groups with incorrect sum:"
+            list `by' `group_sum' if `group_diff' > `tol' & `touse', noobs sepby(`by')
+            
+            exit 9
+        }
+    }
+    else {
+        // Check overall sum
+        quietly summarize `varlist' if `touse'
+        local actual_sum = r(sum)
+        local diff = abs(`actual_sum' - `expected')
+        
+        if `diff' > `tol' {
+            display as error ""
+            display as error "ASSERTION FAILED: assert_sum_equals"
+            display as error "  Variable: `varlist'"
+            display as error "  Expected sum: `expected'"
+            display as error "  Actual sum: `actual_sum'"
+            display as error "  Difference: `diff'"
+            display as error "  Tolerance: `tol'"
+            if "`message'" != "" {
+                display as error "  Message: `message'"
+            }
+            exit 9
+        }
+    }
+end

--- a/src/statatest/ado/econ/fixtures/fixture_multilevel_panel.ado
+++ b/src/statatest/ado/econ/fixtures/fixture_multilevel_panel.ado
@@ -1,0 +1,95 @@
+*! fixture_multilevel_panel.ado
+*! Version 1.0.0
+*! Creates a multilevel/hierarchical panel dataset for testing
+*!
+*! Syntax:
+*!   fixture_multilevel_panel [, n_groups(#) n_units(#) n_periods(#) ///
+*!                               start_year(#) seed(#)]
+*!
+*! Options:
+*!   n_groups(#)   - Number of top-level groups (default: 5)
+*!   n_units(#)    - Units per group (default: 10)
+*!   n_periods(#)  - Number of time periods (default: 5)
+*!   start_year(#) - Starting year (default: 2015)
+*!   seed(#)       - Random seed (default: 12345)
+*!
+*! Creates variables:
+*!   group_id  - Top-level group identifier (e.g., country, industry)
+*!   unit_id   - Unit within group (e.g., firm within country)
+*!   year      - Time period
+*!   value     - Random value with group and unit effects
+*!
+*! Structure:
+*!   - Hierarchical: groups contain units
+*!   - Panel: units observed over time
+*!   - Example: country × firm × year
+
+program define fixture_multilevel_panel
+    version 16
+    
+    syntax [, n_groups(integer 5) n_units(integer 10) n_periods(integer 5) ///
+              start_year(integer 2015) seed(integer 12345)]
+    
+    clear
+    set seed `seed'
+    
+    // Total observations
+    local total_units = `n_groups' * `n_units'
+    local n_obs = `total_units' * `n_periods'
+    set obs `n_obs'
+    
+    // Create hierarchical structure
+    // group_id: 1, 1, ..., 1, 2, 2, ..., 2, ...
+    gen int group_id = floor((_n - 1) / (`n_units' * `n_periods')) + 1
+    
+    // unit_id: 1, 2, ..., n_units (within each group-year)
+    gen int unit_id = mod(floor((_n - 1) / `n_periods'), `n_units') + 1
+    
+    // year
+    gen int year = `start_year' + mod(_n - 1, `n_periods')
+    
+    // Create unique panel identifier (group-unit combination)
+    gen long panel_id = (group_id - 1) * `n_units' + unit_id
+    
+    // Generate group effects (e.g., country-level differences)
+    tempvar group_effect
+    gen double `group_effect' = 0
+    forvalues g = 1/`n_groups' {
+        local ge = rnormal(0, 10)
+        replace `group_effect' = `ge' if group_id == `g'
+    }
+    
+    // Generate unit effects (e.g., firm-level differences within country)
+    tempvar unit_effect
+    gen double `unit_effect' = rnormal(0, 15)
+    bysort group_id unit_id: replace `unit_effect' = `unit_effect'[1]
+    
+    // Generate value with hierarchical structure
+    gen double value = 100 + `group_effect' + `unit_effect' + rnormal(0, 5)
+    
+    // Sort and set panel
+    sort group_id unit_id year
+    xtset panel_id year
+    
+    // Labels
+    label variable group_id "Group identifier (e.g., country)"
+    label variable unit_id "Unit within group (e.g., firm)"
+    label variable year "Time period"
+    label variable panel_id "Unique panel identifier"
+    label variable value "Value with group and unit effects"
+    
+    // Return info
+    return scalar n_groups = `n_groups'
+    return scalar n_units = `n_units'
+    return scalar n_periods = `n_periods'
+    return scalar n_obs = `n_obs'
+end
+
+// Aliases for common multilevel structures
+program define fixture_country_firm_panel
+    fixture_multilevel_panel `0'
+end
+
+program define fixture_industry_firm_panel
+    fixture_multilevel_panel `0'
+end

--- a/src/statatest/ado/econ/fixtures/fixture_unbalanced_panel.ado
+++ b/src/statatest/ado/econ/fixtures/fixture_unbalanced_panel.ado
@@ -1,0 +1,105 @@
+*! fixture_unbalanced_panel.ado
+*! Version 1.0.0
+*! Creates an unbalanced panel dataset with gaps for testing
+*!
+*! Syntax:
+*!   fixture_unbalanced_panel [, n_units(#) n_periods(#) start_year(#) ///
+*!                               attrition(#) entry(#) seed(#)]
+*!
+*! Options:
+*!   n_units(#)    - Number of panel units (default: 20)
+*!   n_periods(#)  - Number of time periods (default: 10)
+*!   start_year(#) - Starting year (default: 2010)
+*!   attrition(#)  - Annual attrition rate 0-1 (default: 0.1)
+*!   entry(#)      - Annual entry rate 0-1 (default: 0.05)
+*!   seed(#)       - Random seed (default: 12345)
+*!
+*! Creates variables:
+*!   id    - Panel unit identifier
+*!   year  - Time period
+*!   value - Random normal value
+*!
+*! Structure:
+*!   - Units may enter after start_year
+*!   - Units may exit before end_year
+*!   - Creates realistic unbalanced structure
+
+program define fixture_unbalanced_panel
+    version 16
+    
+    syntax [, n_units(integer 20) n_periods(integer 10) start_year(integer 2010) ///
+              attrition(real 0.1) entry(real 0.05) seed(integer 12345)]
+    
+    clear
+    set seed `seed'
+    
+    // Validate rates
+    if `attrition' < 0 | `attrition' > 1 {
+        display as error "attrition() must be between 0 and 1"
+        exit 198
+    }
+    if `entry' < 0 | `entry' > 1 {
+        display as error "entry() must be between 0 and 1"
+        exit 198
+    }
+    
+    // Start with balanced panel
+    local n_obs = `n_units' * `n_periods'
+    set obs `n_obs'
+    
+    gen int id = mod(_n - 1, `n_units') + 1
+    gen int year = `start_year' + floor((_n - 1) / `n_units')
+    
+    // Generate entry year for each unit (some enter late)
+    tempvar entry_year exit_year
+    gen int `entry_year' = `start_year'
+    gen int `exit_year' = `start_year' + `n_periods' - 1
+    
+    // Assign random entry years (some units enter after start)
+    forvalues i = 1/`n_units' {
+        if runiform() < `entry' * `n_periods' / 2 {
+            local delay = ceil(runiform() * (`n_periods' / 2))
+            replace `entry_year' = `start_year' + `delay' if id == `i'
+        }
+    }
+    
+    // Assign random exit years (some units exit early - attrition)
+    forvalues i = 1/`n_units' {
+        if runiform() < `attrition' * `n_periods' / 2 {
+            local early_exit = ceil(runiform() * (`n_periods' / 2))
+            replace `exit_year' = `start_year' + `n_periods' - 1 - `early_exit' if id == `i'
+        }
+    }
+    
+    // Keep only observations within entry-exit window
+    drop if year < `entry_year' | year > `exit_year'
+    
+    // Add some random gaps (intermittent missingness)
+    gen byte _drop = runiform() < 0.05
+    drop if _drop
+    drop _drop
+    
+    // Generate value
+    gen double value = rnormal(100, 20)
+    
+    // Sort and set panel (will have gaps)
+    sort id year
+    xtset id year
+    
+    // Labels
+    label variable id "Panel unit identifier"
+    label variable year "Time period"
+    label variable value "Random value"
+    
+    // Return info
+    quietly count
+    return scalar n_obs = r(N)
+    quietly distinct id
+    return scalar n_units = r(ndistinct)
+    return scalar n_periods = `n_periods'
+end
+
+// Alias
+program define fixture_unbalanced_firm_panel
+    fixture_unbalanced_panel `0'
+end


### PR DESCRIPTION
## Summary

Add remaining economic fixtures and assertions for panel data and accounting identity testing.

## Changes

### New Fixtures

| Fixture | Description | Aliases |
|---------|-------------|---------|
| `fixture_unbalanced_panel` | Panel with attrition, entry, gaps | `fixture_unbalanced_firm_panel` |
| `fixture_multilevel_panel` | Hierarchical panel (group × unit × year) | `fixture_country_firm_panel`, `fixture_industry_firm_panel` |

### New Assertions

| Assertion | Description | gtools |
|-----------|-------------|--------|
| `assert_panel_structure` | Verify xtset, uniqueness, balanced option | `gisid` |
| `assert_positive` | Check all values > 0, strict option | - |
| `assert_sorted` | Verify sort order preserved | `hashsort` |
| `assert_sum_equals` | Sum equals expected, by-group support | `gegen` |
| `assert_identity` | Accounting identities (A + B == C) | - |

### Example Usage

```stata
// Panel structure validation
fixture_balanced_panel
assert_panel_structure id year, balanced
assert_unique id year
assert_sorted id year

// Accounting identity
assert_identity assets == liabilities + equity
assert_sum_equals share, expected(1) by(group)
```

## Test plan

- [x] Files created with proper structure
- [x] Consistent syntax across assertions
- [x] gtools integration where beneficial
- [ ] Stata integration tests (requires Stata)
- [ ] Documentation (future PR)

Related to #7 (Stata integration tests will validate these)