### PR TITLE
docs: add econ extension documentation and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **[econ] extension** - Economic data fixtures and assertions (`pip install statatest[econ]`)
+  - Panel fixtures:
+    - `fixture_balanced_panel` - Balanced firm-year panel
+    - `fixture_unbalanced_panel` - Panel with attrition, entry, gaps
+    - `fixture_multilevel_panel` - Hierarchical panel (group × unit × year)
+  - Network fixtures:
+    - `fixture_production_network` - Sparse directed weighted network (Bernard & Zi 2022)
+    - `fixture_bipartite_network` - AKM employer-employee structure
+  - Economic assertions:
+    - `assert_unique` - ID uniqueness (uses gisid for performance)
+    - `assert_no_missing` - No missing values
+    - `assert_positive` - All values positive
+    - `assert_sorted` - Sort order preserved (uses hashsort)
+    - `assert_panel_structure` - Valid xtset with balanced option
+    - `assert_sum_equals` - Sum equals expected with by-group support
+    - `assert_identity` - Accounting identities (A + B == C)
 - Fixture system with pytest-like `conftest.do` pattern
 - Built-in fixtures:
   - `use_fixture` - Request a fixture by name

--- a/docs/extensions/econ.md
+++ b/docs/extensions/econ.md
@@ -1,0 +1,294 @@
+# statatest[econ]
+
+Economic data fixtures and assertions for panel data, networks, and accounting identities.
+
+## Installation
+
+```bash
+pip install statatest[econ]
+```
+
+## Features
+
+- **Panel Fixtures**: Balanced, unbalanced, and multilevel panels
+- **Network Fixtures**: Production networks and bipartite employer-employee data
+- **Economic Assertions**: Panel structure, uniqueness, accounting identities
+- **gtools Integration**: Uses gisid, hashsort for performance on large datasets
+
+---
+
+## Panel Fixtures
+
+### fixture_balanced_panel
+
+Creates a balanced panel dataset (all units observed in all periods).
+
+```stata
+fixture_balanced_panel [, n_units(#) n_periods(#) start_year(#) seed(#)]
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `n_units` | 10 | Number of panel units |
+| `n_periods` | 5 | Number of time periods |
+| `start_year` | 2015 | Starting year |
+| `seed` | 12345 | Random seed |
+
+**Creates:** `id`, `year`, `value`
+
+**Example:**
+
+```stata
+fixture_balanced_panel, n_units(100) n_periods(10)
+assert_panel_structure id year, balanced
+```
+
+**Alias:** `fixture_firm_panel`
+
+---
+
+### fixture_unbalanced_panel
+
+Creates an unbalanced panel with entry, exit, and gaps.
+
+```stata
+fixture_unbalanced_panel [, n_units(#) n_periods(#) start_year(#) ///
+                            attrition(#) entry(#) seed(#)]
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `attrition` | 0.1 | Annual attrition rate (0-1) |
+| `entry` | 0.05 | Annual entry rate (0-1) |
+
+**Creates:** `id`, `year`, `value` (with gaps)
+
+**Alias:** `fixture_unbalanced_firm_panel`
+
+---
+
+### fixture_multilevel_panel
+
+Creates a hierarchical panel (e.g., country × firm × year).
+
+```stata
+fixture_multilevel_panel [, n_groups(#) n_units(#) n_periods(#) ///
+                            start_year(#) seed(#)]
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `n_groups` | 5 | Number of top-level groups |
+| `n_units` | 10 | Units per group |
+
+**Creates:** `group_id`, `unit_id`, `year`, `panel_id`, `value`
+
+**Aliases:** `fixture_country_firm_panel`, `fixture_industry_firm_panel`
+
+---
+
+## Network Fixtures
+
+### fixture_production_network
+
+Creates a sparse directed weighted network following Bernard & Zi (2022).
+
+```stata
+fixture_production_network [, n_firms(#) n_edges(#) temporal seed(#)]
+```
+
+**Structure:**
+
+- ~31% only buyers, ~13% only sellers, ~56% both
+- Log-normal transaction weights
+- Directed edges (seller → buyer)
+
+**Creates:** `seller`, `buyer`, `weight`, `year` (if temporal)
+
+**Aliases:** `fixture_trade_network`, `fixture_supply_chain`
+
+!!! note "Not Bipartite"
+    Production networks are NOT bipartite—firms can be both buyers and sellers.
+
+---
+
+### fixture_bipartite_network
+
+Creates a bipartite employer-employee network following AKM structure.
+
+```stata
+fixture_bipartite_network [, n_workers(#) n_firms(#) n_periods(#) ///
+                             start_year(#) mobility(#) seed(#)]
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `n_workers` | 500 | Number of workers |
+| `n_firms` | 50 | Number of firms |
+| `mobility` | 0.15 | Job switching rate (0-1) |
+
+**Structure:**
+
+- Two distinct node types (workers ↔ firms)
+- AKM wage decomposition: `log(wage) = worker_effect + firm_effect + residual`
+
+**Creates:** `worker_id`, `firm_id`, `year`, `wage`
+
+**Aliases:** `fixture_employer_employee`, `fixture_matched_panel`
+
+---
+
+## Assertions
+
+### assert_unique
+
+Check that variable combination uniquely identifies observations.
+
+```stata
+assert_unique varlist [if] [, by(varlist) message(string)]
+```
+
+Uses `gisid` internally for performance.
+
+**Example:**
+
+```stata
+assert_unique id year
+assert_unique seller buyer, by(year)
+```
+
+---
+
+### assert_no_missing
+
+Check that variables have no missing values.
+
+```stata
+assert_no_missing varlist [if] [, message(string)]
+```
+
+---
+
+### assert_positive
+
+Check that all values are positive.
+
+```stata
+assert_positive varname [if] [, strict message(string)]
+```
+
+**Options:**
+
+- `strict`: Require `> 0` (default is `>= 0`)
+
+---
+
+### assert_sorted
+
+Check that data is sorted by specified variables.
+
+```stata
+assert_sorted varlist [, message(string)]
+```
+
+Uses `hashsort` for verification if available.
+
+---
+
+### assert_panel_structure
+
+Check that data has valid panel structure.
+
+```stata
+assert_panel_structure [panelvar timevar] [, balanced message(string)]
+```
+
+**Options:**
+
+- `balanced`: Require all units have all periods
+
+**Example:**
+
+```stata
+// Check current xtset
+assert_panel_structure
+
+// Check specific variables
+assert_panel_structure id year, balanced
+```
+
+---
+
+### assert_sum_equals
+
+Check that sum equals expected value.
+
+```stata
+assert_sum_equals varname [if], expected(#) [tol(#) by(varlist) message(string)]
+```
+
+**Example:**
+
+```stata
+// Shares sum to 1
+assert_sum_equals share, expected(1)
+
+// Sum by group
+assert_sum_equals weight, expected(100) by(group)
+```
+
+---
+
+### assert_identity
+
+Check accounting identity (row-wise equality).
+
+```stata
+assert_identity exp1 == exp2 [if] [, tol(#) message(string)]
+```
+
+**Example:**
+
+```stata
+assert_identity assets == liabilities + equity
+assert_identity fob + freight + insurance == cif, tol(0.01)
+```
+
+---
+
+## Full Example
+
+```stata
+// Create test data
+fixture_balanced_panel, n_units(100) n_periods(5)
+
+// Validate structure
+assert_panel_structure id year, balanced
+assert_unique id year
+assert_sorted id year
+assert_no_missing id year value
+assert_positive value, strict
+
+// Add derived variables
+gen double share = value / 100
+bysort year: egen double total = total(share)
+
+// Check accounting
+assert_sum_equals share, expected(1) by(year) tol(0.01)
+```
+
+---
+
+## See Also
+
+- [Econ Assertions Reference](../reference/econ-assertions.md)
+- [Econ Fixtures Reference](../reference/econ-fixtures.md)
+- [Core Assertions](../guide/assertions.md)

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -1,0 +1,47 @@
+# Extensions
+
+statatest supports optional extensions that add domain-specific fixtures and assertions.
+
+## Available Extensions
+
+| Extension | Install Command | Description |
+|-----------|-----------------|-------------|
+| **[econ](econ.md)** | `pip install statatest[econ]` | Economic data fixtures and assertions |
+
+## Installing Extensions
+
+Extensions are installed as optional extras:
+
+```bash
+# Install with econ extension
+pip install statatest[econ]
+
+# Install with multiple extensions
+pip install statatest[econ,other]
+
+# Install all extensions
+pip install statatest[all]
+```
+
+## Using Extensions
+
+Extensions add .ado files that are automatically available when the extension is installed:
+
+```stata
+// Panel fixtures (from [econ])
+fixture_balanced_panel, n_units(100) n_periods(10)
+
+// Economic assertions (from [econ])
+assert_panel_structure id year, balanced
+assert_unique id year
+```
+
+## Creating Custom Extensions
+
+Extensions are simply collections of .ado files in the `statatest/ado/` directory. To create a custom extension:
+
+1. Add .ado files to `src/statatest/ado/<extension>/`
+2. Register the extra in `pyproject.toml`
+3. Document in `docs/extensions/`
+
+See the [econ extension source](https://github.com/jigonr/statatest/tree/main/src/statatest/ado/econ) for reference.

--- a/docs/reference/assertions.md
+++ b/docs/reference/assertions.md
@@ -1,0 +1,187 @@
+# Core Assertions Reference
+
+Built-in assertions available in the base statatest package.
+
+## assert_equal
+
+Check that two values are equal.
+
+```stata
+assert_equal value, expected(expected_value) [message(string)]
+```
+
+**Parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `value` | Yes | Actual value to test |
+| `expected()` | Yes | Expected value |
+| `message()` | No | Custom error message |
+
+**Example:**
+
+```stata
+local result = "success"
+assert_equal "`result'", expected("success")
+```
+
+---
+
+## assert_true
+
+Check that expression evaluates to true (non-zero).
+
+```stata
+assert_true expression [, message(string)]
+```
+
+**Example:**
+
+```stata
+assert_true 1 == 1
+assert_true `r(N)' > 0
+```
+
+---
+
+## assert_false
+
+Check that expression evaluates to false (zero).
+
+```stata
+assert_false expression [, message(string)]
+```
+
+**Example:**
+
+```stata
+assert_false 1 == 0
+assert_false missing(`r(mean)')
+```
+
+---
+
+## assert_error
+
+Check that a command produces an error.
+
+```stata
+assert_error "command_string"
+```
+
+**Example:**
+
+```stata
+assert_error "drop nonexistent_variable"
+```
+
+---
+
+## assert_noerror
+
+Check that a command executes without error.
+
+```stata
+assert_noerror "command_string"
+```
+
+**Example:**
+
+```stata
+assert_noerror "summarize x"
+```
+
+---
+
+## assert_var_exists
+
+Check that a variable exists in the dataset.
+
+```stata
+assert_var_exists varname [, message(string)]
+```
+
+**Example:**
+
+```stata
+assert_var_exists id
+assert_var_exists wage, message("Wage variable required")
+```
+
+---
+
+## assert_file_exists
+
+Check that a file exists on disk.
+
+```stata
+assert_file_exists "filepath" [, message(string)]
+```
+
+**Example:**
+
+```stata
+assert_file_exists "data/input.dta"
+```
+
+---
+
+## assert_approx_equal
+
+Check that two numeric values are approximately equal.
+
+```stata
+assert_approx_equal value, expected(#) [tol(#) message(string)]
+```
+
+**Parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `tol()` | 1e-6 | Tolerance for comparison |
+
+**Example:**
+
+```stata
+assert_approx_equal `r(mean)', expected(0.5) tol(0.01)
+```
+
+---
+
+## assert_obs_count
+
+Check that observation count matches expected.
+
+```stata
+assert_obs_count # [if] [, message(string)]
+```
+
+**Example:**
+
+```stata
+assert_obs_count 100
+assert_obs_count 50 if group == 1
+```
+
+---
+
+## assert_in_range
+
+Check that value is within specified range.
+
+```stata
+assert_in_range value, min(#) max(#) [message(string)]
+```
+
+**Example:**
+
+```stata
+assert_in_range `r(r2)', min(0) max(1)
+```
+
+---
+
+## See Also
+
+- [Assertions Guide](../guide/assertions.md)
+- [Econ Assertions](econ-assertions.md) (requires `[econ]` extension)

--- a/docs/reference/econ-assertions.md
+++ b/docs/reference/econ-assertions.md
@@ -1,0 +1,193 @@
+# Econ Assertions Reference
+
+Assertions for economic data validation. Requires `pip install statatest[econ]`.
+
+## assert_unique
+
+Check that variable combination uniquely identifies observations.
+
+```stata
+assert_unique varlist [if] [, by(varlist) message(string)]
+```
+
+**Parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `varlist` | Yes | Variables that should uniquely identify |
+| `by()` | No | Check uniqueness within groups |
+| `message()` | No | Custom error message |
+
+**Performance:** Uses `gisid` if available.
+
+**Examples:**
+
+```stata
+assert_unique id year
+assert_unique seller buyer, by(year)
+assert_unique worker_id firm_id year
+```
+
+---
+
+## assert_no_missing
+
+Check that variables have no missing values.
+
+```stata
+assert_no_missing varlist [if] [, message(string)]
+```
+
+**Example:**
+
+```stata
+assert_no_missing id year value
+assert_no_missing wage if year >= 2015
+```
+
+---
+
+## assert_positive
+
+Check that all values are positive.
+
+```stata
+assert_positive varname [if] [, strict message(string)]
+```
+
+**Parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `strict` | off | If specified, requires `> 0`; otherwise `>= 0` |
+
+**Examples:**
+
+```stata
+assert_positive sales
+assert_positive wage, strict message("Wages must be positive")
+```
+
+---
+
+## assert_sorted
+
+Check that data is sorted by specified variables.
+
+```stata
+assert_sorted varlist [, message(string)]
+```
+
+**Performance:** Uses `hashsort` for verification if available.
+
+**Example:**
+
+```stata
+assert_sorted id year
+assert_sorted seller buyer year
+```
+
+---
+
+## assert_panel_structure
+
+Check that data has valid panel structure (xtset).
+
+```stata
+assert_panel_structure [panelvar timevar] [, balanced message(string)]
+```
+
+**Parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `panelvar timevar` | No | If omitted, checks current xtset |
+| `balanced` | No | Require all units have all periods |
+
+**Checks:**
+
+1. Data can be xtset with specified variables
+2. No duplicate panel-time combinations
+3. (If `balanced`) All units observed in all periods
+
+**Examples:**
+
+```stata
+// Check current xtset
+xtset id year
+assert_panel_structure
+
+// Check and set specific variables
+assert_panel_structure id year
+
+// Require balanced panel
+assert_panel_structure id year, balanced
+```
+
+---
+
+## assert_sum_equals
+
+Check that sum of variable equals expected value.
+
+```stata
+assert_sum_equals varname [if], expected(#) [tol(#) by(varlist) message(string)]
+```
+
+**Parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `expected()` | Required | Expected sum value |
+| `tol()` | 1e-10 | Tolerance for comparison |
+| `by()` | None | Check sum within each group |
+
+**Examples:**
+
+```stata
+// Shares sum to 1
+assert_sum_equals share, expected(1)
+
+// With tolerance
+assert_sum_equals weight, expected(100) tol(0.01)
+
+// By group
+assert_sum_equals market_share, expected(1) by(industry year)
+```
+
+---
+
+## assert_identity
+
+Check accounting identity (row-wise equality).
+
+```stata
+assert_identity exp1 == exp2 [if] [, tol(#) message(string)]
+```
+
+**Parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `tol()` | 1e-10 | Tolerance for numeric comparison |
+
+**Examples:**
+
+```stata
+// Balance sheet identity
+assert_identity assets == liabilities + equity
+
+// Trade costs
+assert_identity fob + freight + insurance == cif, tol(0.01)
+
+// Income statement
+assert_identity revenue - costs == profit if year == 2020
+```
+
+---
+
+## See Also
+
+- [statatest[econ] Guide](../extensions/econ.md)
+- [Econ Fixtures Reference](econ-fixtures.md)
+- [Core Assertions](assertions.md)

--- a/docs/reference/econ-fixtures.md
+++ b/docs/reference/econ-fixtures.md
@@ -1,0 +1,194 @@
+# Econ Fixtures Reference
+
+Fixtures for economic data structures. Requires `pip install statatest[econ]`.
+
+## Panel Fixtures
+
+### fixture_balanced_panel
+
+Creates a balanced panel dataset.
+
+```stata
+fixture_balanced_panel [, n_units(#) n_periods(#) start_year(#) seed(#)]
+```
+
+**Parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `n_units` | 10 | Number of panel units |
+| `n_periods` | 5 | Number of time periods |
+| `start_year` | 2015 | Starting year |
+| `seed` | 12345 | Random seed for reproducibility |
+
+**Creates:**
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `id` | int | Panel unit identifier (1 to n_units) |
+| `year` | int | Time period |
+| `value` | double | Random normal (mean=100, sd=20) |
+
+**Returns:**
+
+- `r(n_units)` - Number of units
+- `r(n_periods)` - Number of periods
+- `r(n_obs)` - Total observations
+
+**Side effects:** Sets `xtset id year`
+
+**Alias:** `fixture_firm_panel`
+
+---
+
+### fixture_unbalanced_panel
+
+Creates an unbalanced panel with entry, attrition, and gaps.
+
+```stata
+fixture_unbalanced_panel [, n_units(#) n_periods(#) start_year(#) ///
+                            attrition(#) entry(#) seed(#)]
+```
+
+**Parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `n_units` | 20 | Number of panel units |
+| `n_periods` | 10 | Number of time periods |
+| `start_year` | 2010 | Starting year |
+| `attrition` | 0.1 | Annual attrition rate (0-1) |
+| `entry` | 0.05 | Annual entry rate (0-1) |
+| `seed` | 12345 | Random seed |
+
+**Creates:** `id`, `year`, `value` (with gaps)
+
+**Alias:** `fixture_unbalanced_firm_panel`
+
+---
+
+### fixture_multilevel_panel
+
+Creates a hierarchical/multilevel panel.
+
+```stata
+fixture_multilevel_panel [, n_groups(#) n_units(#) n_periods(#) ///
+                            start_year(#) seed(#)]
+```
+
+**Parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `n_groups` | 5 | Number of top-level groups |
+| `n_units` | 10 | Units per group |
+| `n_periods` | 5 | Time periods |
+| `start_year` | 2015 | Starting year |
+| `seed` | 12345 | Random seed |
+
+**Creates:**
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `group_id` | int | Top-level group (e.g., country) |
+| `unit_id` | int | Unit within group (e.g., firm) |
+| `year` | int | Time period |
+| `panel_id` | long | Unique panel identifier |
+| `value` | double | Value with group and unit effects |
+
+**Aliases:** `fixture_country_firm_panel`, `fixture_industry_firm_panel`
+
+---
+
+## Network Fixtures
+
+### fixture_production_network
+
+Creates a sparse directed weighted production network.
+
+```stata
+fixture_production_network [, n_firms(#) n_edges(#) temporal seed(#)]
+```
+
+**Parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `n_firms` | 100 | Total number of firms |
+| `n_edges` | 500 | Number of edges |
+| `temporal` | off | Add year dimension (2015-2019) |
+| `seed` | 12345 | Random seed |
+
+**Creates:**
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `seller` | int | Seller firm ID (source node) |
+| `buyer` | int | Buyer firm ID (target node) |
+| `weight` | double | Transaction value (log-normal) |
+| `year` | int | Year (if `temporal` specified) |
+
+**Network Properties (Bernard & Zi 2022):**
+
+- ~31% only buyers
+- ~13% only sellers
+- ~56% both buyers and sellers
+- Directed: seller → buyer
+- Weighted: log-normal transaction values
+- **NOT bipartite**: firms can be both
+
+**Aliases:** `fixture_trade_network`, `fixture_supply_chain`
+
+---
+
+### fixture_bipartite_network
+
+Creates a bipartite employer-employee network (AKM structure).
+
+```stata
+fixture_bipartite_network [, n_workers(#) n_firms(#) n_periods(#) ///
+                             start_year(#) mobility(#) seed(#)]
+```
+
+**Parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `n_workers` | 500 | Number of workers |
+| `n_firms` | 50 | Number of firms |
+| `n_periods` | 5 | Time periods |
+| `start_year` | 2015 | Starting year |
+| `mobility` | 0.15 | Job switching probability (0-1) |
+| `seed` | 12345 | Random seed |
+
+**Creates:**
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `worker_id` | int | Worker identifier |
+| `firm_id` | int | Firm identifier |
+| `year` | int | Year |
+| `wage` | double | Wage (AKM structure) |
+
+**AKM Structure:**
+
+```
+log(wage) = worker_effect + firm_effect + experience + residual
+```
+
+- Worker effects: N(0, 0.3)
+- Firm effects: N(0, 0.2)
+- Experience: 2% return per year
+- Residual: N(0, 0.15)
+
+**Bipartite Property:** Two distinct node types; edges only between workers and firms.
+
+**Aliases:** `fixture_employer_employee`, `fixture_matched_panel`
+
+---
+
+## See Also
+
+- [statatest[econ] Guide](../extensions/econ.md)
+- [Econ Assertions Reference](econ-assertions.md)
+- [Core Fixtures](../guide/fixtures.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,9 +47,15 @@ nav:
   - CI Integration:
       - GitHub Actions: ci/github-actions.md
       - Codecov: ci/codecov.md
+  - Extensions:
+      - Overview: extensions/index.md
+      - "statatest[econ]": extensions/econ.md
   - Reference:
       - CLI: reference/cli.md
       - Configuration: reference/config.md
+      - Core Assertions: reference/assertions.md
+      - Econ Assertions: reference/econ-assertions.md
+      - Econ Fixtures: reference/econ-fixtures.md
   - Migration: migration.md
 
 markdown_extensions:

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]
-provides-extras = ["dev", "docs"]
+provides-extras = ["dev", "docs", "econ"]
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
## Summary

Add comprehensive documentation for the `statatest[econ]` extension.

## Changes

### New Documentation Pages

| Page | Description |
|------|-------------|
| `docs/extensions/index.md` | Extensions overview |
| `docs/extensions/econ.md` | Comprehensive [econ] guide |
| `docs/reference/assertions.md` | Core assertions API |
| `docs/reference/econ-assertions.md` | Econ assertions API |
| `docs/reference/econ-fixtures.md` | Econ fixtures API |

### CHANGELOG Update

Added [econ] extension to Unreleased section following keepachangelog.com format.

### Navigation Structure

```
Extensions:
  - Overview
  - statatest[econ]
Reference:
  - CLI
  - Configuration  
  - Core Assertions (new)
  - Econ Assertions (new)
  - Econ Fixtures (new)
```

## Test plan

- [x] MkDocs builds with --strict
- [x] All pages render correctly
- [x] Internal links verified
- [x] CHANGELOG follows keepachangelog format

Related to #12, #13, #14