### PR TITLE
refactor(config): OOP redesign with classmethod factory + remove adopath_mode

### DIFF
--- a/src/statatest/cli.py
+++ b/src/statatest/cli.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 import click
 
 from statatest import __version__
-from statatest.core.config import Config, load_config
+from statatest.core.config import Config
 from statatest.core.logging import Colors, colorize, configure_logging
 from statatest.coverage.instrument import (
     cleanup_instrumented_environment,
@@ -173,7 +173,7 @@ def main(
     configure_logging(verbose)
 
     # Load configuration
-    config = load_config(Path.cwd())
+    config = Config.from_project(Path.cwd())
     if verbose:
         config.verbose = True
 

--- a/src/statatest/core/__init__.py
+++ b/src/statatest/core/__init__.py
@@ -6,7 +6,7 @@ This module contains the foundational components used across statatest:
 - constants: Magic numbers and default values
 """
 
-from statatest.core.config import Config, load_config
+from statatest.core.config import Config
 from statatest.core.constants import (
     COVERAGE_HIGH_THRESHOLD,
     COVERAGE_MEDIUM_THRESHOLD,
@@ -31,5 +31,4 @@ __all__ = [
     "TestFile",
     "TestResult",
     "TestSuite",
-    "load_config",
 ]

--- a/src/statatest/execution/executor.py
+++ b/src/statatest/execution/executor.py
@@ -129,7 +129,7 @@ def _prepare_environment(
     Returns:
         TestEnvironment with paths to temporary files.
     """
-    ado_paths = _get_ado_paths_for_mode(config)
+    ado_paths = _get_ado_paths()
     conftest_files = discover_conftest(test.path.parent)
 
     wrapper_content = create_wrapper_do(
@@ -220,29 +220,6 @@ def _cleanup_environment(env: TestEnvironment) -> None:
     for path in [env.log_path, env.wrapper_path]:
         with contextlib.suppress(FileNotFoundError):
             path.unlink()
-
-
-def _get_ado_paths_for_mode(config: Config) -> dict[str, Path]:
-    """Get ado paths based on configuration mode.
-
-    Args:
-        config: Configuration with adopath_mode and adopath settings.
-
-    Returns:
-        Dictionary of ado paths to add. Empty dict if user manages paths.
-    """
-    if config.adopath_mode == "none":
-        return {}
-
-    if config.adopath_mode == "custom":
-        return {f"custom_{i}": Path(p) for i, p in enumerate(config.adopath)}
-
-    # Default "auto" mode
-    paths = _get_ado_paths()
-    for i, custom_path in enumerate(config.adopath):
-        paths[f"custom_{i}"] = Path(custom_path)
-
-    return paths
 
 
 def _get_ado_paths() -> dict[str, Path]:

--- a/src/statatest/execution/wrapper.py
+++ b/src/statatest/execution/wrapper.py
@@ -21,14 +21,14 @@ def create_wrapper_do(
     The wrapper executes in this order:
     1. Clear and set Stata options
     2. Add instrumented directory (for coverage) - highest priority
-    3. Add ado paths (if adopath_mode is not "none")
+    3. Add statatest ado paths (assertions, fixtures)
     4. Run setup_do (if configured)
     5. Load conftest.do files (fixtures and shared setup)
     6. Run the actual test
 
     Args:
         test_path: Path to the test file.
-        ado_paths: Dictionary of ado paths to add. May be empty if user manages paths.
+        ado_paths: Dictionary of ado paths to add (statatest assertions/fixtures).
         conftest_files: List of conftest.do files to load (in order).
         instrumented_dir: Path to instrumented source files (for coverage).
         setup_do: Optional path to a setup.do file for custom initialization.


### PR DESCRIPTION
## Summary

Major Config refactor following OOP principles (Information Expert, Factory Method).

## Changes

### Before (Procedural Anti-pattern)
```python
# External function creates/mutates object
def load_config(project_root: Path) -> Config:
    config = Config()
    _apply_settings(config, settings)  # Mutation!
    return config
```

### After (Proper OOP)
```python
@dataclass
class Config:
    @classmethod
    def from_project(cls, project_root: Path) -> Config:
        """Factory method - Config knows how to create itself."""
        settings = cls._load_settings(project_root)
        return cls(**settings)
```

## Files Modified

| File | Changes |
|------|---------|
| `core/config.py` | Complete rewrite with OOP pattern |
| `core/__init__.py` | Remove `load_config` export |
| `cli.py` | `load_config()` → `Config.from_project()` |
| `execution/executor.py` | Remove `_get_ado_paths_for_mode()` |
| `execution/wrapper.py` | Update docstring |
| `tests/test_config.py` | Rename tests, remove adopath tests |

## Removed

- `adopath_mode` field (use `setup_do` instead)
- `adopath` field (use `setup_do` instead)
- `load_config()` function (use `Config.from_project()`)
- `_apply_settings()`, `_apply_core_settings()`, etc.

## Test plan

- [x] All 87 tests pass
- [x] Coverage at 90%
- [x] config.py at 100% coverage
- [x] mypy --strict passes
- [x] ruff check passes
- [x] No `load_config` references remain
- [x] No `adopath_mode` references remain
- [ ] CI passes (including codecov/patch)

## Verification

```bash
grep -rn "load_config" src/ tests/  # Empty ✓
grep -rn "adopath_mode" src/ tests/  # Empty ✓
grep -rn "from_project" src/  # Exists ✓
```

Closes #35