### PR TITLE
fix(executor): improve Stata invocation to match documented usage

### DIFF
--- a/src/statatest/execution/executor.py
+++ b/src/statatest/execution/executor.py
@@ -132,8 +132,9 @@ def _prepare_environment(
     ado_paths = _get_ado_paths()
     conftest_files = discover_conftest(test.path.parent)
 
+    # Use relative path for test file (we run from test.path.parent)
     wrapper_content = create_wrapper_do(
-        test_path=test.path,
+        test_path=Path(test.path.name),
         ado_paths=ado_paths,
         conftest_files=conftest_files,
         instrumented_dir=instrumented_dir,
@@ -179,12 +180,13 @@ def _execute_stata(
     start_time = time.time()
     log_flag = "-s" if coverage else "-b"
 
+    # Stata usage: stata-mp [-h -q -s -b] ["stata command"]
+    # The command should be a single quoted argument
     cmd = [
         config.stata_executable,
         log_flag,
         "-q",
-        "do",
-        str(env.wrapper_path),
+        f"do {env.wrapper_path}",
     ]
 
     process = subprocess.run(  # noqa: S603


### PR DESCRIPTION
## Summary

Improve Stata subprocess invocation to match documented usage.

## Changes

### Stata Command

**Before:**
```python
cmd = [stata_executable, "-s", "-q", "do", str(wrapper_path)]
# Results in: stata-mp -s -q do /tmp/wrapper.do (5 args)
```

**After:**
```python
cmd = [stata_executable, "-s", "-q", f"do {wrapper_path}"]
# Results in: stata-mp -s -q "do /tmp/wrapper.do" (4 args)
```

This matches Stata's documented usage:
```
stata-mp [-h -q -s -b] ["stata command"]
```

### Paths

| Path | Before | After |
|------|--------|-------|
| Test file in wrapper | Absolute `/full/path/test.do` | Relative `test.do` |
| Working directory | `test.path.parent` | Same (unchanged) |
| Ado paths | Absolute | Same (required) |
| Wrapper path | Absolute | Same (in temp dir) |

### Flags Used

- `-s`: Creates .smcl log (for coverage - preserves SMCL markers)
- `-b`: Creates .log file (for non-coverage runs)
- `-q`: Suppresses logo/initialization messages

## Test plan

- [x] All 87 tests pass
- [x] mypy --strict passes
- [x] ruff check passes
- [ ] CI passes