### PR TITLE
feat(assertions): add assert_count, assert_var_type, assert_label_exists

### DIFF
--- a/src/statatest/ado/assertions/assert_count.ado
+++ b/src/statatest/ado/assertions/assert_count.ado
@@ -1,0 +1,42 @@
+*! assert_count v1.0.0  statatest  2025-12-30
+*! Assert that the dataset has the expected number of observations.
+*!
+*! Syntax:
+*!   assert_count, expected(integer) [if] [message(string)]
+*!
+*! Examples:
+*!   sysuse auto, clear
+*!   assert_count, expected(74)
+*!   assert_count if foreign == 1, expected(22)
+
+program define assert_count, rclass
+    version 16
+
+    syntax [if], Expected(integer) [Message(string)]
+
+    // Count observations (with optional if condition)
+    if `"`if'"' != "" {
+        quietly count `if'
+    }
+    else {
+        quietly count
+    }
+    local actual = r(N)
+
+    // Compare actual vs expected
+    if `actual' != `expected' {
+        display as error "ASSERTION FAILED: assert_count"
+        display as error "  Expected: `expected' observations"
+        display as error "  Actual:   `actual' observations"
+        if `"`message'"' != "" {
+            display as error "  Message:  `message'"
+        }
+        noisily display "_STATATEST_FAIL_:assert_count_:`actual' != `expected'_END_"
+        exit 9
+    }
+
+    noisily display "_STATATEST_PASS_:assert_count_"
+
+    return local passed "1"
+    return scalar count = `actual'
+end

--- a/src/statatest/ado/assertions/assert_label_exists.ado
+++ b/src/statatest/ado/assertions/assert_label_exists.ado
@@ -1,0 +1,37 @@
+*! assert_label_exists v1.0.0  statatest  2025-12-30
+*! Assert that a variable has value labels attached.
+*!
+*! Syntax:
+*!   assert_label_exists varname [, message(string)]
+*!
+*! Examples:
+*!   sysuse auto, clear
+*!   assert_label_exists foreign
+*!   assert_label_exists rep78, message("rep78 should have labels")
+
+program define assert_label_exists, rclass
+    version 16
+    
+    syntax varname [, Message(string)]
+    
+    // Get the value label attached to the variable
+    local label_name : value label `varlist'
+    
+    // Check if label is attached (empty means no label)
+    if "`label_name'" == "" {
+        display as error "ASSERTION FAILED: assert_label_exists"
+        display as error "  Variable: `varlist'"
+        display as error "  Expected: value label attached"
+        display as error "  Actual:   no value label"
+        if `"`message'"' != "" {
+            display as error "  Message:  `message'"
+        }
+        noisily display "_STATATEST_FAIL_:assert_label_exists_:`varlist' has no label_END_"
+        exit 9
+    }
+    
+    noisily display "_STATATEST_PASS_:assert_label_exists_"
+    
+    return local passed "1"
+    return local label_name "`label_name'"
+end

--- a/src/statatest/ado/assertions/assert_var_type.ado
+++ b/src/statatest/ado/assertions/assert_var_type.ado
@@ -1,0 +1,61 @@
+*! assert_var_type v1.0.0  statatest  2025-12-30
+*! Assert that a variable has the expected type.
+*!
+*! Syntax:
+*!   assert_var_type varname, type(string) [message(string)]
+*!
+*! Type options: numeric, string, byte, int, long, float, double, str#
+*!
+*! Examples:
+*!   sysuse auto, clear
+*!   assert_var_type price, type("numeric")
+*!   assert_var_type make, type("string")
+*!   assert_var_type mpg, type("int")
+
+program define assert_var_type, rclass
+    version 16
+    
+    syntax varname, Type(string) [Message(string)]
+    
+    // Get actual type using extended macro function
+    local actual_type : type `varlist'
+    
+    // Determine if type matches (handle categories: numeric, string)
+    local type_match = 0
+    
+    if "`type'" == "numeric" {
+        // Check if any numeric type
+        if inlist("`actual_type'", "byte", "int", "long", "float", "double") {
+            local type_match = 1
+        }
+    }
+    else if "`type'" == "string" {
+        // Check if any string type (starts with "str")
+        if substr("`actual_type'", 1, 3) == "str" {
+            local type_match = 1
+        }
+    }
+    else {
+        // Exact type match
+        if "`actual_type'" == "`type'" {
+            local type_match = 1
+        }
+    }
+    
+    if `type_match' == 0 {
+        display as error "ASSERTION FAILED: assert_var_type"
+        display as error "  Variable: `varlist'"
+        display as error "  Expected type: `type'"
+        display as error "  Actual type:   `actual_type'"
+        if `"`message'"' != "" {
+            display as error "  Message:  `message'"
+        }
+        noisily display "_STATATEST_FAIL_:assert_var_type_:`varlist' is `actual_type' not `type'_END_"
+        exit 9
+    }
+    
+    noisily display "_STATATEST_PASS_:assert_var_type_"
+    
+    return local passed "1"
+    return local var_type "`actual_type'"
+end


### PR DESCRIPTION
## Summary

Add three new assertion commands for testing Stata code.

### New Assertions

| Assertion | Description | Example |
|-----------|-------------|---------|
| `assert_count` | Verify dataset has expected number of observations | `assert_count, expected(74)` |
| `assert_var_type` | Verify variable has expected type | `assert_var_type price, type("numeric")` |
| `assert_label_exists` | Verify variable has value labels attached | `assert_label_exists foreign` |

### Details

**assert_count** (#37)
- Supports `if` condition: `assert_count if foreign == 1, expected(22)`
- Returns actual count in `r(count)`

**assert_var_type** (#38)
- Supports categories: `numeric`, `string`
- Supports specific types: `byte`, `int`, `long`, `float`, `double`, `str#`
- Returns actual type in `r(var_type)`

**assert_label_exists** (#39)
- Checks if value label is attached (not if label values exist)
- Returns label name in `r(label_name)`

## Test Plan

- [x] All 89 Python tests pass
- [ ] Manual testing with Stata (ado files follow existing patterns)

Closes #37, Closes #38, Closes #39