### PR TITLE
feat(ado): add verbose option to all assertions and fixtures

### DIFF
--- a/src/statatest/ado/assertions/assert_approx_equal.ado
+++ b/src/statatest/ado/assertions/assert_approx_equal.ado
@@ -1,35 +1,44 @@
-*! assert_approx_equal v1.0.0  statatest  2025-12-26
+*! assert_approx_equal v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Assert that two numeric values are approximately equal within tolerance.
 *!
 *! Syntax:
-*!   assert_approx_equal actual, expected(number) [tol(number) message(string)]
+*!   assert_approx_equal actual, expected(number) [tol(number) message(string) verbose]
 *!
 *! Example:
 *!   assert_approx_equal `r(mean)', expected(0.5) tol(0.01)
-*!   assert_approx_equal 3.14159, expected(3.14) tol(0.01)
+*!   assert_approx_equal 3.14159, expected(3.14) tol(0.01) verbose
 
 program define assert_approx_equal, rclass
     version 16
 
-    syntax anything(name=actual), Expected(real) [TOL(real 1e-6) Message(string)]
+    syntax anything(name=actual), Expected(real) [TOL(real 1e-6) Message(string) Verbose]
 
     // Calculate absolute difference
     local diff = abs(`actual' - `expected')
 
     if `diff' > `tol' {
-        display as error "ASSERTION FAILED: assert_approx_equal"
-        display as error "  Expected: `expected'"
-        display as error "  Actual:   `actual'"
-        display as error "  Diff:     `diff'"
-        display as error "  Tol:      `tol'"
-        if `"`message'"' != "" {
-            display as error "  Message:  `message'"
+        if "`verbose'" != "" {
+            display as error "ASSERTION FAILED: assert_approx_equal"
+            display as error "  Expected: `expected'"
+            display as error "  Actual:   `actual'"
+            display as error "  Diff:     `diff'"
+            display as error "  Tol:      `tol'"
+            if `"`message'"' != "" {
+                display as error "  Message:  `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_approx_equal: `actual' !≈ `expected' (tol=`tol')"
         }
         // Emit failure marker
         noisily display "_STATATEST_FAIL_:assert_approx_equal_:diff `diff' > tol `tol'_END_"
         exit 9
+    }
+
+    if "`verbose'" != "" {
+        display as text "PASS: assert_approx_equal"
     }
 
     // Emit success marker

--- a/src/statatest/ado/assertions/assert_count.ado
+++ b/src/statatest/ado/assertions/assert_count.ado
@@ -1,8 +1,8 @@
-*! assert_count v1.0.0  statatest  2025-12-30
+*! assert_count v1.1.0  statatest  2025-12-30
 *! Assert that the dataset has the expected number of observations.
 *!
 *! Syntax:
-*!   assert_count, expected(integer) [if] [message(string)]
+*!   assert_count, expected(integer) [if] [message(string)] [Verbose]
 *!
 *! Examples:
 *!   sysuse auto, clear
@@ -12,7 +12,7 @@
 program define assert_count, rclass
     version 16
 
-    syntax [if], Expected(integer) [Message(string)]
+    syntax [if], Expected(integer) [Message(string)] [Verbose]
 
     // Count observations (with optional if condition)
     if `"`if'"' != "" {
@@ -25,16 +25,24 @@ program define assert_count, rclass
 
     // Compare actual vs expected
     if `actual' != `expected' {
-        display as error "ASSERTION FAILED: assert_count"
-        display as error "  Expected: `expected' observations"
-        display as error "  Actual:   `actual' observations"
-        if `"`message'"' != "" {
-            display as error "  Message:  `message'"
+        if "`verbose'" != "" {
+            display as error "ASSERTION FAILED: assert_count"
+            display as error "  Expected: `expected' observations"
+            display as error "  Actual:   `actual' observations"
+            if `"`message'"' != "" {
+                display as error "  Message:  `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_count: `actual' != `expected' observations"
         }
         noisily display "_STATATEST_FAIL_:assert_count_:`actual' != `expected'_END_"
         exit 9
     }
 
+    if "`verbose'" != "" {
+        display as text "PASS: assert_count"
+    }
     noisily display "_STATATEST_PASS_:assert_count_"
 
     return local passed "1"

--- a/src/statatest/ado/assertions/assert_equal.ado
+++ b/src/statatest/ado/assertions/assert_equal.ado
@@ -1,39 +1,50 @@
-*! assert_equal v1.0.0  statatest  2025-12-26
-*! Author: Jose Ignacio Gonzalez Rojas
+*! assert_equal v1.1.0  statatest  2025-12-30
 *!
 *! Assert that two values are equal.
 *!
 *! Syntax:
-*!   assert_equal actual, expected(value) [message(string)]
+*!   assert_equal actual, expected(value) [message(string) verbose]
+*!
+*! Options:
+*!   verbose  - Show detailed output (expected vs actual values)
 *!
 *! Example:
 *!   assert_equal "`r(N)'", expected("100")
-*!   assert_equal `x', expected(5) message("x should be 5")
+*!   assert_equal `x', expected(5) message("x should be 5") verbose
 
 program define assert_equal, rclass
     version 16
 
-    syntax anything(name=actual), Expected(string) [Message(string)]
+    syntax anything(name=actual), Expected(string) [Message(string) Verbose]
 
     // Use capture assert to test equality
     capture assert `"`actual'"' == `"`expected'"'
 
     if _rc == 9 {
-        display as error "ASSERTION FAILED: assert_equal"
-        display as error "  Expected: `expected'"
-        display as error "  Actual:   `actual'"
+        // Minimal output by default
+        if "`verbose'" == "" {
+            display as error "FAIL: assert_equal: `actual' != `expected'"
+        }
+        else {
+            // Verbose: detailed output
+            display as error "ASSERTION FAILED: assert_equal"
+            display as error "  Expected: `expected'"
+            display as error "  Actual:   `actual'"
+        }
         if `"`message'"' != "" {
             display as error "  Message:  `message'"
         }
-        // Emit failure marker for Python to parse
         noisily display "_STATATEST_FAIL_:assert_equal_:`actual' != `expected'_END_"
         exit 9
     }
     else if _rc != 0 {
-        error _rc  // Propagate unexpected errors
+        error _rc
     }
 
-    // Emit success marker for Python to parse
+    // Success: minimal by default, show PASS with verbose
+    if "`verbose'" != "" {
+        display as text "PASS: assert_equal"
+    }
     noisily display "_STATATEST_PASS_:assert_equal_"
 
     return local passed "1"

--- a/src/statatest/ado/assertions/assert_error.ado
+++ b/src/statatest/ado/assertions/assert_error.ado
@@ -1,31 +1,36 @@
-*! assert_error v1.0.0  statatest  2025-12-26
+*! assert_error v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Assert that a command produces an error.
 *!
 *! Syntax:
-*!   assert_error "command" [, rc(integer) message(string)]
+*!   assert_error "command" [, rc(integer) message(string) verbose]
 *!
 *! Example:
 *!   assert_error "use nonexistent_file.dta"
-*!   assert_error "gen x = invalid", rc(198)
+*!   assert_error "gen x = invalid", rc(198) verbose
 
 program define assert_error, rclass
     version 16
 
-    syntax anything(name=command) [, RC(integer 0) Message(string)]
+    syntax anything(name=command) [, RC(integer 0) Message(string) Verbose]
 
     // Execute the command and capture the return code
     capture `command'
     local actual_rc = _rc
 
     if `actual_rc' == 0 {
-        display as error "ASSERTION FAILED: assert_error"
-        display as error "  Command:  `command'"
-        display as error "  Expected: error"
-        display as error "  Actual:   no error (rc=0)"
-        if `"`message'"' != "" {
-            display as error "  Message:  `message'"
+        if "`verbose'" != "" {
+            display as error "ASSERTION FAILED: assert_error"
+            display as error "  Command:  `command'"
+            display as error "  Expected: error"
+            display as error "  Actual:   no error (rc=0)"
+            if `"`message'"' != "" {
+                display as error "  Message:  `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_error: command succeeded (expected error)"
         }
         // Emit failure marker
         noisily display "_STATATEST_FAIL_:assert_error_:command did not fail_END_"
@@ -34,16 +39,25 @@ program define assert_error, rclass
 
     // If specific rc requested, check it
     if `rc' != 0 & `actual_rc' != `rc' {
-        display as error "ASSERTION FAILED: assert_error"
-        display as error "  Command:  `command'"
-        display as error "  Expected: rc=`rc'"
-        display as error "  Actual:   rc=`actual_rc'"
-        if `"`message'"' != "" {
-            display as error "  Message:  `message'"
+        if "`verbose'" != "" {
+            display as error "ASSERTION FAILED: assert_error"
+            display as error "  Command:  `command'"
+            display as error "  Expected: rc=`rc'"
+            display as error "  Actual:   rc=`actual_rc'"
+            if `"`message'"' != "" {
+                display as error "  Message:  `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_error: got rc=`actual_rc', expected rc=`rc'"
         }
         // Emit failure marker
         noisily display "_STATATEST_FAIL_:assert_error_:wrong rc `actual_rc' != `rc'_END_"
         exit 9
+    }
+
+    if "`verbose'" != "" {
+        display as text "PASS: assert_error"
     }
 
     // Emit success marker

--- a/src/statatest/ado/assertions/assert_false.ado
+++ b/src/statatest/ado/assertions/assert_false.ado
@@ -1,10 +1,10 @@
-*! assert_false v1.0.0  statatest  2025-12-26
+*! assert_false v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Assert that a condition evaluates to false.
 *!
 *! Syntax:
-*!   assert_false condition [, message(string)]
+*!   assert_false condition [, message(string) verbose]
 *!
 *! Example:
 *!   assert_false missing(x)
@@ -13,17 +13,22 @@
 program define assert_false, rclass
     version 16
 
-    syntax anything(name=condition) [, Message(string)]
+    syntax anything(name=condition) [, Message(string) Verbose]
 
     // Use capture assert to test that condition is false (NOT condition is true)
     capture assert !(`condition')
 
     if _rc == 9 {
-        display as error "ASSERTION FAILED: assert_false"
-        display as error "  Condition: `condition'"
-        display as error "  Evaluated: true (expected false)"
-        if `"`message'"' != "" {
-            display as error "  Message:   `message'"
+        if "`verbose'" != "" {
+            display as error "ASSERTION FAILED: assert_false"
+            display as error "  Condition: `condition'"
+            display as error "  Evaluated: true (expected false)"
+            if `"`message'"' != "" {
+                display as error "  Message:   `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_false: `condition' is true"
         }
         // Emit failure marker
         noisily display "_STATATEST_FAIL_:assert_false_:`condition' is true_END_"
@@ -33,8 +38,10 @@ program define assert_false, rclass
         error _rc
     }
 
-    // Emit success marker
-    noisily display "_STATATEST_PASS_:assert_false_"
+    // Success: display only if verbose option
+    if "`verbose'" != "" {
+        display as text "PASS: assert_false"
+    }
 
     return local passed "1"
 end

--- a/src/statatest/ado/assertions/assert_file_exists.ado
+++ b/src/statatest/ado/assertions/assert_file_exists.ado
@@ -1,38 +1,52 @@
-*! assert_file_exists v1.0.0  statatest  2025-12-26
+*! assert_file_exists v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Assert that a file exists at the specified path.
 *!
 *! Syntax:
-*!   assert_file_exists "path" [, message(string)]
+*!   assert_file_exists "path" [, message(string) Verbose]
+*!
+*! Options:
+*!   message(string) - Custom error message
+*!   Verbose         - Show detailed messages on success and failure
 *!
 *! Example:
 *!   assert_file_exists "data/input.dta"
-*!   assert_file_exists "`c(sysdir_plus)'ado/base/r/regress.ado"
+*!   assert_file_exists "`c(sysdir_plus)'ado/base/r/regress.ado", verbose
 
 program define assert_file_exists, rclass
     version 16
 
-    syntax anything(name=filepath) [, Message(string)]
+    syntax anything(name=filepath) [, Message(string) Verbose]
 
     // Remove quotes if present
-    local filepath = subinstr(`"`filepath'"', `"""', "", .)
+    local filepath = subinstr(`"`filepath'"', `""""', "", .)
 
     // Check if file exists
     capture confirm file `"`filepath'"'
 
     if _rc != 0 {
-        display as error "ASSERTION FAILED: assert_file_exists"
-        display as error "  File:    `filepath'"
-        display as error "  Status:  does not exist"
-        if `"`message'"' != "" {
-            display as error "  Message: `message'"
+        if "`verbose'" != "" {
+            display as error "ASSERTION FAILED: assert_file_exists"
+            display as error "  File:    `filepath'"
+            display as error "  Status:  does not exist"
+            if `"`message'"' != "" {
+                display as error "  Message: `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_file_exists: `filepath' not found"
         }
         // Emit failure marker
         noisily display "_STATATEST_FAIL_:assert_file_exists_:`filepath' not found_END_"
         exit 601
     }
 
+    // Success
+    if "`verbose'" != "" {
+        display as text "PASS: assert_file_exists"
+    }
+    
     // Emit success marker
     noisily display "_STATATEST_PASS_:assert_file_exists_"
 

--- a/src/statatest/ado/assertions/assert_identity.ado
+++ b/src/statatest/ado/assertions/assert_identity.ado
@@ -1,18 +1,19 @@
 *! assert_identity.ado
-*! Version 1.0.0
+*! Version 1.1.0  2025-12-30
 *! Assert that an accounting identity holds (row-wise equality)
 *!
 *! Syntax:
-*!   assert_identity exp1 == exp2 [if] [, tol(#) message(string)]
+*!   assert_identity exp1 == exp2 [if] [, tol(#) message(string) verbose]
 *!
 *! Options:
 *!   tol(#)        - Tolerance for numeric comparison (default: 1e-10)
 *!   message(str)  - Custom error message
+*!   verbose       - Show detailed output (PASS on success, full details on failure)
 *!
 *! Examples:
 *!   assert_identity assets == liabilities + equity
 *!   assert_identity fob + freight + insurance == cif, tol(0.01)
-*!   assert_identity revenue - costs == profit if year == 2020
+*!   assert_identity revenue - costs == profit if year == 2020, verbose
 
 program define assert_identity
     version 16
@@ -28,7 +29,7 @@ program define assert_identity
     
     // Parse RHS and options
     local 0 `rest'
-    syntax anything [if] [, tol(real 1e-10) message(string)]
+    syntax anything [if] [, tol(real 1e-10) message(string) Verbose]
     local rhs `anything'
     
     marksample touse, novarlist
@@ -55,29 +56,39 @@ program define assert_identity
     local n_fail = r(N)
     
     if `n_fail' > 0 {
-        display as error ""
-        display as error "ASSERTION FAILED: assert_identity"
-        display as error "  Identity: `lhs' == `rhs'"
-        display as error "  Tolerance: `tol'"
-        display as error "  `n_fail' observations violate the identity"
-        if "`message'" != "" {
-            display as error "  Message: `message'"
+        if "`verbose'" != "" {
+            display as error ""
+            display as error "ASSERTION FAILED: assert_identity"
+            display as error "  Identity: `lhs' == `rhs'"
+            display as error "  Tolerance: `tol'"
+            display as error "  `n_fail' observations violate the identity"
+            if "`message'" != "" {
+                display as error "  Message: `message'"
+            }
+            
+            // Show summary of differences
+            display as error ""
+            display as error "  Summary of differences:"
+            summarize `diff' if `diff' > `tol' & `touse', detail
+            
+            // Show first few violations
+            display as error ""
+            display as error "  First 5 violations:"
+            gen double _lhs = `lhs_val'
+            gen double _rhs = `rhs_val'
+            gen double _diff = `diff'
+            list _lhs _rhs _diff if `diff' > `tol' & `touse' in 1/5, noobs
+            drop _lhs _rhs _diff
+        }
+        else {
+            display as error "FAIL: assert_identity: identity check failed"
         }
         
-        // Show summary of differences
-        display as error ""
-        display as error "  Summary of differences:"
-        summarize `diff' if `diff' > `tol' & `touse', detail
-        
-        // Show first few violations
-        display as error ""
-        display as error "  First 5 violations:"
-        gen double _lhs = `lhs_val'
-        gen double _rhs = `rhs_val'
-        gen double _diff = `diff'
-        list _lhs _rhs _diff if `diff' > `tol' & `touse' in 1/5, noobs
-        drop _lhs _rhs _diff
-        
         exit 9
+    }
+    
+    // Success message (only if verbose)
+    if "`verbose'" != "" {
+        display as text "PASS: assert_identity"
     }
 end

--- a/src/statatest/ado/assertions/assert_in_range.ado
+++ b/src/statatest/ado/assertions/assert_in_range.ado
@@ -1,10 +1,10 @@
-*! assert_in_range v1.0.0  statatest  2025-12-26
+*! assert_in_range v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Assert that a value is within a specified range.
 *!
 *! Syntax:
-*!   assert_in_range value, min(number) max(number) [message(string)]
+*!   assert_in_range value, min(number) max(number) [message(string)] [verbose]
 *!
 *! Example:
 *!   assert_in_range `r(mean)', min(0) max(100)
@@ -13,21 +13,26 @@
 program define assert_in_range, rclass
     version 16
 
-    syntax anything(name=value), MIN(real) MAX(real) [Message(string)]
+    syntax anything(name=value), MIN(real) MAX(real) [Message(string) Verbose]
 
     if `value' < `min' | `value' > `max' {
-        display as error "ASSERTION FAILED: assert_in_range"
-        display as error "  Value:    `value'"
-        display as error "  Min:      `min'"
-        display as error "  Max:      `max'"
-        if `value' < `min' {
-            display as error "  Status:   value < min"
+        if "`verbose'" != "" {
+            display as error "ASSERTION FAILED: assert_in_range"
+            display as error "  Value:    `value'"
+            display as error "  Min:      `min'"
+            display as error "  Max:      `max'"
+            if `value' < `min' {
+                display as error "  Status:   value < min"
+            }
+            else {
+                display as error "  Status:   value > max"
+            }
+            if `\"`message'\"' != "" {
+                display as error "  Message:  `message'"
+            }
         }
         else {
-            display as error "  Status:   value > max"
-        }
-        if `"`message'"' != "" {
-            display as error "  Message:  `message'"
+            display as error "FAIL: assert_in_range: `value' not in [`min', `max']"
         }
         // Emit failure marker
         noisily display "_STATATEST_FAIL_:assert_in_range_:`value' not in [`min', `max']_END_"
@@ -35,7 +40,13 @@ program define assert_in_range, rclass
     }
 
     // Emit success marker
-    noisily display "_STATATEST_PASS_:assert_in_range_"
+    if "`verbose'" != "" {
+        noisily display "_STATATEST_PASS_:assert_in_range_"
+        display as text "PASS: assert_in_range"
+    }
+    else {
+        noisily display "_STATATEST_PASS_:assert_in_range_"
+    }
 
     return local passed "1"
 end

--- a/src/statatest/ado/assertions/assert_label_exists.ado
+++ b/src/statatest/ado/assertions/assert_label_exists.ado
@@ -1,8 +1,8 @@
-*! assert_label_exists v1.0.0  statatest  2025-12-30
+*! assert_label_exists v1.1.0  statatest  2025-12-30
 *! Assert that a variable has value labels attached.
 *!
 *! Syntax:
-*!   assert_label_exists varname [, message(string)]
+*!   assert_label_exists varname [, message(string)] [Verbose]
 *!
 *! Examples:
 *!   sysuse auto, clear
@@ -12,24 +12,32 @@
 program define assert_label_exists, rclass
     version 16
     
-    syntax varname [, Message(string)]
+    syntax varname [, Message(string)] [Verbose]
     
     // Get the value label attached to the variable
     local label_name : value label `varlist'
     
     // Check if label is attached (empty means no label)
     if "`label_name'" == "" {
-        display as error "ASSERTION FAILED: assert_label_exists"
-        display as error "  Variable: `varlist'"
-        display as error "  Expected: value label attached"
-        display as error "  Actual:   no value label"
-        if `"`message'"' != "" {
-            display as error "  Message:  `message'"
+        if "`verbose'" != "" {
+            display as error "ASSERTION FAILED: assert_label_exists"
+            display as error "  Variable: `varlist'"
+            display as error "  Expected: value label attached"
+            display as error "  Actual:   no value label"
+            if `"`message'"' != "" {
+                display as error "  Message:  `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_label_exists: `varlist' has no value label"
         }
         noisily display "_STATATEST_FAIL_:assert_label_exists_:`varlist' has no label_END_"
         exit 9
     }
     
+    if "`verbose'" != "" {
+        display as text "PASS: assert_label_exists"
+    }
     noisily display "_STATATEST_PASS_:assert_label_exists_"
     
     return local passed "1"

--- a/src/statatest/ado/assertions/assert_no_missing.ado
+++ b/src/statatest/ado/assertions/assert_no_missing.ado
@@ -1,18 +1,23 @@
 *! assert_no_missing.ado
-*! Version 1.0.0
+*! Version 1.1.0, 2025-12-30
 *! Assert that variables have no missing values
 *!
 *! Syntax:
-*!   assert_no_missing varlist [if] [, message(string)]
+*!   assert_no_missing varlist [if] [, message(string) Verbose]
+*!
+*! Options:
+*!   message(str)  - Custom error message
+*!   Verbose       - Show detailed output (PASS on success, details on failure)
 *!
 *! Examples:
 *!   assert_no_missing id year value
 *!   assert_no_missing sales if year >= 2015
+*!   assert_no_missing id year, Verbose
 
 program define assert_no_missing
     version 16
     
-    syntax varlist [if] [, message(string)]
+    syntax varlist [if] [, message(string) Verbose]
     
     marksample touse, novarlist
     
@@ -28,13 +33,23 @@ program define assert_no_missing
     }
     
     if `has_missing' {
-        display as error ""
-        display as error "ASSERTION FAILED: assert_no_missing"
-        display as error "  Variables with missing values:"
-        display as error "   `missing_vars'"
-        if "`message'" != "" {
-            display as error "  Message: `message'"
+        if "`verbose'" != "" {
+            display as error ""
+            display as error "ASSERTION FAILED: assert_no_missing"
+            display as error "  Variables with missing values:"
+            display as error "   `missing_vars'"
+            if "`message'" != "" {
+                display as error "  Message: `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_no_missing: `varlist' has missing values"
         }
         exit 9
+    }
+    else {
+        if "`verbose'" != "" {
+            display as text "PASS: assert_no_missing: `varlist' has no missing values"
+        }
     }
 end

--- a/src/statatest/ado/assertions/assert_noerror.ado
+++ b/src/statatest/ado/assertions/assert_noerror.ado
@@ -1,35 +1,44 @@
-*! assert_noerror v1.0.0  statatest  2025-12-26
+*! assert_noerror v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Assert that a command succeeds without error.
 *!
 *! Syntax:
-*!   assert_noerror "command" [, message(string)]
+*!   assert_noerror "command" [, message(string) verbose]
 *!
 *! Example:
 *!   assert_noerror "gen x = 1"
-*!   assert_noerror "regress y x", message("Regression should succeed")
+*!   assert_noerror "regress y x", message("Regression should succeed") verbose
 
 program define assert_noerror, rclass
     version 16
 
-    syntax anything(name=command) [, Message(string)]
+    syntax anything(name=command) [, Message(string) Verbose]
 
     // Execute the command and capture the return code
     capture `command'
     local actual_rc = _rc
 
     if `actual_rc' != 0 {
-        display as error "ASSERTION FAILED: assert_noerror"
-        display as error "  Command:  `command'"
-        display as error "  Expected: success (rc=0)"
-        display as error "  Actual:   rc=`actual_rc'"
-        if `"`message'"' != "" {
-            display as error "  Message:  `message'"
+        if "`verbose'" != "" {
+            display as error "ASSERTION FAILED: assert_noerror"
+            display as error "  Command:  `command'"
+            display as error "  Expected: success (rc=0)"
+            display as error "  Actual:   rc=`actual_rc'"
+            if `"`message'"' != "" {
+                display as error "  Message:  `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_noerror: command failed with rc=`actual_rc'"
         }
         // Emit failure marker
         noisily display "_STATATEST_FAIL_:assert_noerror_:rc=`actual_rc'_END_"
         exit 9
+    }
+
+    if "`verbose'" != "" {
+        display as text "PASS: assert_noerror"
     }
 
     // Emit success marker

--- a/src/statatest/ado/assertions/assert_obs_count.ado
+++ b/src/statatest/ado/assertions/assert_obs_count.ado
@@ -1,19 +1,23 @@
-*! assert_obs_count v1.0.0  statatest  2025-12-26
+*! assert_obs_count v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Assert that the observation count matches expected value.
 *!
 *! Syntax:
-*!   assert_obs_count expected [if] [, message(string)]
+*!   assert_obs_count expected [if] [, message(string) verbose]
+*!
+*! Options:
+*!   message(str)  - Custom error message
+*!   verbose       - Show detailed output (PASS on success, full details on failure)
 *!
 *! Example:
 *!   assert_obs_count 100
-*!   assert_obs_count 50 if foreign == 1
+*!   assert_obs_count 50 if foreign == 1, verbose
 
 program define assert_obs_count, rclass
     version 16
 
-    syntax anything(name=expected) [if] [, Message(string)]
+    syntax anything(name=expected) [if] [, Message(string) Verbose]
 
     // Count observations
     if `"`if'"' != "" {
@@ -25,21 +29,29 @@ program define assert_obs_count, rclass
     local actual = r(N)
 
     if `actual' != `expected' {
-        display as error "ASSERTION FAILED: assert_obs_count"
-        display as error "  Expected: `expected'"
-        display as error "  Actual:   `actual'"
-        if `"`if'"' != "" {
-            display as error "  Condition: `if'"
+        if "`verbose'" != "" {
+            display as error "ASSERTION FAILED: assert_obs_count"
+            display as error "  Expected: `expected'"
+            display as error "  Actual:   `actual'"
+            if `"`if'"' != "" {
+                display as error "  Condition: `if'"
+            }
+            if `"`message'"' != "" {
+                display as error "  Message:  `message'"
+            }
         }
-        if `"`message'"' != "" {
-            display as error "  Message:  `message'"
+        else {
+            display as error "FAIL: assert_obs_count: `actual' != `expected' observations"
         }
         // Emit failure marker
         noisily display "_STATATEST_FAIL_:assert_obs_count_:`actual' != `expected'_END_"
         exit 9
     }
 
-    // Emit success marker
+    // Emit success marker (only if verbose)
+    if "`verbose'" != "" {
+        noisily display "PASS: assert_obs_count"
+    }
     noisily display "_STATATEST_PASS_:assert_obs_count_"
 
     return local passed "1"

--- a/src/statatest/ado/assertions/assert_panel_structure.ado
+++ b/src/statatest/ado/assertions/assert_panel_structure.ado
@@ -1,13 +1,14 @@
 *! assert_panel_structure.ado
-*! Version 1.0.0
+*! Version 1.1.0  2025-12-30
 *! Assert that data has valid panel structure (xtset)
 *!
 *! Syntax:
-*!   assert_panel_structure [panelvar timevar] [, balanced message(string)]
+*!   assert_panel_structure [panelvar timevar] [, balanced message(string) verbose]
 *!
 *! Options:
 *!   balanced      - Require balanced panel (all units have all periods)
 *!   message(str)  - Custom error message
+*!   verbose       - Show detailed output (PASS on success, full details on failure)
 *!
 *! If panelvar and timevar not specified, checks current xtset.
 *!
@@ -19,7 +20,7 @@
 program define assert_panel_structure
     version 16
     
-    syntax [varlist(min=0 max=2)] [, balanced message(string)]
+    syntax [varlist(min=0 max=2)] [, balanced message(string) Verbose]
     
     local nvars : word count `varlist'
     
@@ -27,11 +28,16 @@ program define assert_panel_structure
         // Check current xtset
         capture xtset
         if _rc != 0 {
-            display as error ""
-            display as error "ASSERTION FAILED: assert_panel_structure"
-            display as error "  Data is not xtset"
-            if "`message'" != "" {
-                display as error "  Message: `message'"
+            if "`verbose'" != "" {
+                display as error ""
+                display as error "ASSERTION FAILED: assert_panel_structure"
+                display as error "  Data is not xtset"
+                if "`message'" != "" {
+                    display as error "  Message: `message'"
+                }
+            }
+            else {
+                display as error "FAIL: assert_panel_structure: invalid panel structure"
             }
             exit 9
         }
@@ -49,12 +55,17 @@ program define assert_panel_structure
         // Try to xtset with these variables
         capture xtset `panelvar' `timevar'
         if _rc != 0 {
-            display as error ""
-            display as error "ASSERTION FAILED: assert_panel_structure"
-            display as error "  Cannot xtset with: `panelvar' `timevar'"
-            display as error "  Error code: `=_rc'"
-            if "`message'" != "" {
-                display as error "  Message: `message'"
+            if "`verbose'" != "" {
+                display as error ""
+                display as error "ASSERTION FAILED: assert_panel_structure"
+                display as error "  Cannot xtset with: `panelvar' `timevar'"
+                display as error "  Error code: `=_rc'"
+                if "`message'" != "" {
+                    display as error "  Message: `message'"
+                }
+            }
+            else {
+                display as error "FAIL: assert_panel_structure: invalid panel structure"
             }
             exit 9
         }
@@ -70,12 +81,17 @@ program define assert_panel_structure
     }
     
     if _rc != 0 {
-        display as error ""
-        display as error "ASSERTION FAILED: assert_panel_structure"
-        display as error "  Panel variables: `panelvar' `timevar'"
-        display as error "  Not uniquely identified (duplicates exist)"
-        if "`message'" != "" {
-            display as error "  Message: `message'"
+        if "`verbose'" != "" {
+            display as error ""
+            display as error "ASSERTION FAILED: assert_panel_structure"
+            display as error "  Panel variables: `panelvar' `timevar'"
+            display as error "  Not uniquely identified (duplicates exist)"
+            if "`message'" != "" {
+                display as error "  Message: `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_panel_structure: invalid panel structure"
         }
         exit 9
     }
@@ -97,15 +113,25 @@ program define assert_panel_structure
         // Check if all units have same number of periods
         quietly summarize `n_periods_per_unit'
         if r(min) != r(max) | r(min) != `expected_periods' {
-            display as error ""
-            display as error "ASSERTION FAILED: assert_panel_structure"
-            display as error "  Panel is NOT balanced"
-            display as error "  Expected periods per unit: `expected_periods'"
-            display as error "  Actual range: `=r(min)' to `=r(max)'"
-            if "`message'" != "" {
-                display as error "  Message: `message'"
+            if "`verbose'" != "" {
+                display as error ""
+                display as error "ASSERTION FAILED: assert_panel_structure"
+                display as error "  Panel is NOT balanced"
+                display as error "  Expected periods per unit: `expected_periods'"
+                display as error "  Actual range: `=r(min)' to `=r(max)'"
+                if "`message'" != "" {
+                    display as error "  Message: `message'"
+                }
+            }
+            else {
+                display as error "FAIL: assert_panel_structure: invalid panel structure"
             }
             exit 9
         }
+    }
+    
+    // Success message (only if verbose)
+    if "`verbose'" != "" {
+        display as text "PASS: assert_panel_structure"
     }
 end

--- a/src/statatest/ado/assertions/assert_positive.ado
+++ b/src/statatest/ado/assertions/assert_positive.ado
@@ -1,35 +1,42 @@
 *! assert_positive.ado
-*! Version 1.0.0
+*! Version 1.1.0, 2025-12-30
 *! Assert that all values of a variable are positive
 *!
 *! Syntax:
-*!   assert_positive varname [if] [, strict message(string)]
+*!   assert_positive varname [if] [, strict message(string) Verbose]
 *!
 *! Options:
 *!   strict        - Require strictly positive (> 0), not just non-negative
 *!   message(str)  - Custom error message
+*!   Verbose       - Show detailed output (PASS on success, details on failure)
 *!
 *! Examples:
 *!   assert_positive sales
 *!   assert_positive wage, strict message("Wages must be positive")
 *!   assert_positive revenue if year >= 2015
+*!   assert_positive price, Verbose
 
 program define assert_positive
     version 16
     
-    syntax varname [if] [, strict message(string)]
+    syntax varname [if] [, strict message(string) Verbose]
     
     marksample touse
     
     // Check for missing values first
     quietly count if missing(`varlist') & `touse'
     if r(N) > 0 {
-        display as error ""
-        display as error "ASSERTION FAILED: assert_positive"
-        display as error "  Variable: `varlist'"
-        display as error "  Found `r(N)' missing values"
-        if "`message'" != "" {
-            display as error "  Message: `message'"
+        if "`verbose'" != "" {
+            display as error ""
+            display as error "ASSERTION FAILED: assert_positive"
+            display as error "  Variable: `varlist'"
+            display as error "  Found `r(N)' missing values"
+            if "`message'" != "" {
+                display as error "  Message: `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_positive: `varlist' has missing values"
         }
         exit 9
     }
@@ -47,24 +54,33 @@ program define assert_positive
     }
     
     if r(N) > 0 {
-        display as error ""
-        display as error "ASSERTION FAILED: assert_positive"
-        display as error "  Variable: `varlist'"
-        display as error "  Found `r(N)' values `condition'"
-        if "`message'" != "" {
-            display as error "  Message: `message'"
-        }
-        
-        // Show summary of problematic values
-        display as error ""
-        display as error "  Summary of non-positive values:"
-        if "`strict'" != "" {
-            summarize `varlist' if `varlist' <= 0 & `touse', detail
+        if "`verbose'" != "" {
+            display as error ""
+            display as error "ASSERTION FAILED: assert_positive"
+            display as error "  Variable: `varlist'"
+            display as error "  Found `r(N)' values `condition'"
+            if "`message'" != "" {
+                display as error "  Message: `message'"
+            }
+            
+            // Show summary of problematic values
+            display as error ""
+            display as error "  Summary of non-positive values:"
+            if "`strict'" != "" {
+                summarize `varlist' if `varlist' <= 0 & `touse', detail
+            }
+            else {
+                summarize `varlist' if `varlist' < 0 & `touse', detail
+            }
         }
         else {
-            summarize `varlist' if `varlist' < 0 & `touse', detail
+            display as error "FAIL: assert_positive: `varlist' has non-positive values"
         }
-        
         exit 9
+    }
+    else {
+        if "`verbose'" != "" {
+            display as text "PASS: assert_positive: `varlist' has positive values"
+        }
     }
 end

--- a/src/statatest/ado/assertions/assert_sorted.ado
+++ b/src/statatest/ado/assertions/assert_sorted.ado
@@ -1,21 +1,23 @@
 *! assert_sorted.ado
-*! Version 1.0.0
+*! Version 1.1.0, 2025-12-30
 *! Assert that data is sorted by specified variables
 *!
 *! Syntax:
-*!   assert_sorted varlist [, message(string)]
+*!   assert_sorted varlist [, message(string) Verbose]
 *!
 *! Options:
 *!   message(str)  - Custom error message
+*!   Verbose       - Show detailed output (PASS on success, details on failure)
 *!
 *! Examples:
 *!   assert_sorted id year
 *!   assert_sorted firm_id year, message("Data must be sorted by firm-year")
+*!   assert_sorted id year, Verbose
 
 program define assert_sorted
     version 16
     
-    syntax varlist [, message(string)]
+    syntax varlist [, message(string) Verbose]
     
     // Check if data is sorted using hashsort verification if available
     capture which hashsort
@@ -47,14 +49,24 @@ program define assert_sorted
     sort `sortcheck'
     
     if `n_changed' > 0 {
-        display as error ""
-        display as error "ASSERTION FAILED: assert_sorted"
-        display as error "  Variables: `varlist'"
-        display as error "  Data is NOT sorted by these variables"
-        display as error "  `n_changed' observations would change position"
-        if "`message'" != "" {
-            display as error "  Message: `message'"
+        if "`verbose'" != "" {
+            display as error ""
+            display as error "ASSERTION FAILED: assert_sorted"
+            display as error "  Variables: `varlist'"
+            display as error "  Data is NOT sorted by these variables"
+            display as error "  `n_changed' observations would change position"
+            if "`message'" != "" {
+                display as error "  Message: `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_sorted: data not sorted by `varlist'"
         }
         exit 9
+    }
+    else {
+        if "`verbose'" != "" {
+            display as text "PASS: assert_sorted: data sorted by `varlist'"
+        }
     }
 end

--- a/src/statatest/ado/assertions/assert_sum_equals.ado
+++ b/src/statatest/ado/assertions/assert_sum_equals.ado
@@ -1,15 +1,16 @@
 *! assert_sum_equals.ado
-*! Version 1.0.0
+*! Version 1.1.0  2025-12-30
 *! Assert that sum of a variable equals expected value
 *!
 *! Syntax:
-*!   assert_sum_equals varname [if], expected(#) [tol(#) by(varlist) message(string)]
+*!   assert_sum_equals varname [if], expected(#) [tol(#) by(varlist) message(string) verbose]
 *!
 *! Options:
 *!   expected(#)   - Expected sum value (required)
 *!   tol(#)        - Tolerance for comparison (default: 1e-10)
 *!   by(varlist)   - Check sum within each group
 *!   message(str)  - Custom error message
+*!   verbose       - Show detailed output (PASS on success, full details on failure)
 *!
 *! Examples:
 *!   assert_sum_equals share, expected(1)                  // Shares sum to 1
@@ -19,7 +20,7 @@
 program define assert_sum_equals
     version 16
     
-    syntax varname [if], expected(real) [tol(real 1e-10) by(varlist) message(string)]
+    syntax varname [if], expected(real) [tol(real 1e-10) by(varlist) message(string) Verbose]
     
     marksample touse
     
@@ -34,21 +35,28 @@ program define assert_sum_equals
         local n_fail = r(N)
         
         if `n_fail' > 0 {
-            display as error ""
-            display as error "ASSERTION FAILED: assert_sum_equals"
-            display as error "  Variable: `varlist'"
-            display as error "  By groups: `by'"
-            display as error "  Expected sum: `expected'"
-            display as error "  Tolerance: `tol'"
-            display as error "  `n_fail' observations in groups with incorrect sum"
-            if "`message'" != "" {
-                display as error "  Message: `message'"
+            if "`verbose'" != "" {
+                display as error ""
+                display as error "ASSERTION FAILED: assert_sum_equals"
+                display as error "  Variable: `varlist'"
+                display as error "  By groups: `by'"
+                display as error "  Expected sum: `expected'"
+                display as error "  Tolerance: `tol'"
+                display as error "  `n_fail' observations in groups with incorrect sum"
+                if "`message'" != "" {
+                    display as error "  Message: `message'"
+                }
+                
+                // Show failing groups
+                display as error ""
+                display as error "  Groups with incorrect sum:"
+                list `by' `group_sum' if `group_diff' > `tol' & `touse', noobs sepby(`by')
             }
-            
-            // Show failing groups
-            display as error ""
-            display as error "  Groups with incorrect sum:"
-            list `by' `group_sum' if `group_diff' > `tol' & `touse', noobs sepby(`by')
+            else {
+                quietly summarize `group_sum' if `group_diff' > `tol' & `touse'
+                local actual = r(mean)
+                display as error "FAIL: assert_sum_equals: sum(`varlist')=`actual' != `expected'"
+            }
             
             exit 9
         }
@@ -60,17 +68,27 @@ program define assert_sum_equals
         local diff = abs(`actual_sum' - `expected')
         
         if `diff' > `tol' {
-            display as error ""
-            display as error "ASSERTION FAILED: assert_sum_equals"
-            display as error "  Variable: `varlist'"
-            display as error "  Expected sum: `expected'"
-            display as error "  Actual sum: `actual_sum'"
-            display as error "  Difference: `diff'"
-            display as error "  Tolerance: `tol'"
-            if "`message'" != "" {
-                display as error "  Message: `message'"
+            if "`verbose'" != "" {
+                display as error ""
+                display as error "ASSERTION FAILED: assert_sum_equals"
+                display as error "  Variable: `varlist'"
+                display as error "  Expected sum: `expected'"
+                display as error "  Actual sum: `actual_sum'"
+                display as error "  Difference: `diff'"
+                display as error "  Tolerance: `tol'"
+                if "`message'" != "" {
+                    display as error "  Message: `message'"
+                }
+            }
+            else {
+                display as error "FAIL: assert_sum_equals: sum(`varlist')=`actual_sum' != `expected'"
             }
             exit 9
         }
+    }
+    
+    // Success message (only if verbose)
+    if "`verbose'" != "" {
+        display as text "PASS: assert_sum_equals"
     }
 end

--- a/src/statatest/ado/assertions/assert_true.ado
+++ b/src/statatest/ado/assertions/assert_true.ado
@@ -1,29 +1,40 @@
-*! assert_true v1.0.0  statatest  2025-12-26
+*! assert_true v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Assert that a condition evaluates to true.
 *!
 *! Syntax:
-*!   assert_true condition [, message(string)]
+*!   assert_true condition [, message(string) verbose]
+*!
+*! Options:
+*!   verbose: Display detailed output on success/failure
 *!
 *! Example:
 *!   assert_true _N > 0
 *!   assert_true `x' > 5, message("x should be greater than 5")
+*!   assert_true _N > 0, verbose
 
 program define assert_true, rclass
     version 16
 
-    syntax anything(name=condition) [, Message(string)]
+    syntax anything(name=condition) [, Message(string) verbose]
 
     // Use capture assert to test condition
     capture assert `condition'
 
     if _rc == 9 {
-        display as error "ASSERTION FAILED: assert_true"
-        display as error "  Condition: `condition'"
-        display as error "  Evaluated: false"
+        // Minimal output by default
+        if "`verbose'" == "" {
+            display as error "FAIL: assert_true: condition is false"
+        }
+        else {
+            // Verbose: detailed output
+            display as error "ASSERTION FAILED: assert_true"
+            display as error "  Condition: `condition'"
+            display as error "  Evaluated: false"
+        }
         if `"`message'"' != "" {
-            display as error "  Message:   `message'"
+            display as error "  Message:  `message'"
         }
         // Emit failure marker
         noisily display "_STATATEST_FAIL_:assert_true_:`condition' is false_END_"
@@ -31,6 +42,11 @@ program define assert_true, rclass
     }
     else if _rc != 0 {
         error _rc
+    }
+
+    // Success
+    if "`verbose'" != "" {
+        display as text "PASS: assert_true"
     }
 
     // Emit success marker

--- a/src/statatest/ado/assertions/assert_unique.ado
+++ b/src/statatest/ado/assertions/assert_unique.ado
@@ -1,24 +1,26 @@
-*! assert_unique.ado
-*! Version 1.0.0
+*! assert_unique v1.1.0  statatest  2025-12-30
+*! Author: Jose Ignacio Gonzalez Rojas
+*!
 *! Assert that variable combination uniquely identifies observations
 *! Uses gisid internally for performance on large datasets
 *!
 *! Syntax:
-*!   assert_unique varlist [if] [, by(varlist) message(string)]
+*!   assert_unique varlist [if] [, by(varlist) message(string) Verbose]
 *!
 *! Options:
 *!   by(varlist)     - Check uniqueness within groups
 *!   message(string) - Custom error message
+*!   Verbose         - Show detailed messages on success and failure
 *!
 *! Examples:
 *!   assert_unique id year                    // Check id-year is unique
 *!   assert_unique id year, by(country)       // Unique within country
-*!   assert_unique seller buyer, by(year)     // Unique edges per year
+*!   assert_unique seller buyer, by(year) verbose
 
-program define assert_unique
+program define assert_unique, rclass
     version 16
     
-    syntax varlist [if] [, by(varlist) message(string)]
+    syntax varlist [if] [, by(varlist) message(string) Verbose]
     
     // Try gisid first (fast), fall back to isid
     capture which gisid
@@ -58,26 +60,44 @@ program define assert_unique
     local rc = _rc
     
     if `rc' != 0 {
-        display as error ""
-        display as error "ASSERTION FAILED: assert_unique"
-        display as error "  Variables: `varlist'"
-        if "`by'" != "" {
-            display as error "  By groups: `by'"
-        }
-        if "`message'" != "" {
-            display as error "  Message: `message'"
-        }
-        
-        // Show duplicates for debugging
-        display as error ""
-        display as error "  Duplicate observations found. First 5:"
-        if "`by'" != "" {
-            duplicates list `by' `varlist' `if' in 1/5, sepby(`by')
+        if "`verbose'" != "" {
+            display as error ""
+            display as error "ASSERTION FAILED: assert_unique"
+            display as error "  Variables: `varlist'"
+            if "`by'" != "" {
+                display as error "  By groups: `by'"
+            }
+            if "`message'" != "" {
+                display as error "  Message: `message'"
+            }
+            
+            // Show duplicates for debugging
+            display as error ""
+            display as error "  Duplicate observations found. First 5:"
+            if "`by'" != "" {
+                duplicates list `by' `varlist' `if' in 1/5, sepby(`by')
+            }
+            else {
+                duplicates list `varlist' `if' in 1/5
+            }
         }
         else {
-            duplicates list `varlist' `if' in 1/5
+            display as error "FAIL: assert_unique: `varlist' has duplicates"
         }
+        
+        // Emit failure marker
+        noisily display "_STATATEST_FAIL_:assert_unique_:`varlist' has duplicates_END_"
         
         exit 9
     }
+    
+    // Success
+    if "`verbose'" != "" {
+        display as text "PASS: assert_unique"
+    }
+    
+    // Emit success marker
+    noisily display "_STATATEST_PASS_:assert_unique_"
+    
+    return local passed "1"
 end

--- a/src/statatest/ado/assertions/assert_var_exists.ado
+++ b/src/statatest/ado/assertions/assert_var_exists.ado
@@ -1,29 +1,39 @@
-*! assert_var_exists v1.0.0  statatest  2025-12-26
+*! assert_var_exists v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Assert that a variable exists in the current dataset.
 *!
 *! Syntax:
-*!   assert_var_exists varname [, type(string) message(string)]
+*!   assert_var_exists varname [, type(string) message(string) Verbose]
+*!
+*! Options:
+*!   type(string)    - Check variable has specified type
+*!   message(string) - Custom error message
+*!   Verbose         - Show detailed messages on success and failure
 *!
 *! Example:
 *!   assert_var_exists mpg
-*!   assert_var_exists price, type("double")
+*!   assert_var_exists price, type("double") verbose
 
 program define assert_var_exists, rclass
     version 16
 
-    syntax name(name=varname) [, Type(string) Message(string)]
+    syntax name(name=varname) [, Type(string) Message(string) Verbose]
 
     // Check if variable exists
     capture confirm variable `varname'
 
     if _rc != 0 {
-        display as error "ASSERTION FAILED: assert_var_exists"
-        display as error "  Variable: `varname'"
-        display as error "  Status:   does not exist"
-        if `"`message'"' != "" {
-            display as error "  Message:  `message'"
+        if "`verbose'" != "" {
+            display as error "ASSERTION FAILED: assert_var_exists"
+            display as error "  Variable: `varname'"
+            display as error "  Status:   does not exist"
+            if `"`message'"' != "" {
+                display as error "  Message:  `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_var_exists: variable `varname' not found"
         }
         // Emit failure marker
         noisily display "_STATATEST_FAIL_:assert_var_exists_:`varname' not found_END_"
@@ -34,12 +44,17 @@ program define assert_var_exists, rclass
     if `"`type'"' != "" {
         local actual_type : type `varname'
         if "`actual_type'" != "`type'" {
-            display as error "ASSERTION FAILED: assert_var_exists"
-            display as error "  Variable: `varname'"
-            display as error "  Expected type: `type'"
-            display as error "  Actual type:   `actual_type'"
-            if `"`message'"' != "" {
-                display as error "  Message:  `message'"
+            if "`verbose'" != "" {
+                display as error "ASSERTION FAILED: assert_var_exists"
+                display as error "  Variable: `varname'"
+                display as error "  Expected type: `type'"
+                display as error "  Actual type:   `actual_type'"
+                if `"`message'"' != "" {
+                    display as error "  Message:  `message'"
+                }
+            }
+            else {
+                display as error "FAIL: assert_var_exists: variable `varname' type mismatch"
             }
             // Emit failure marker
             noisily display "_STATATEST_FAIL_:assert_var_exists_:type `actual_type' != `type'_END_"
@@ -47,6 +62,11 @@ program define assert_var_exists, rclass
         }
     }
 
+    // Success
+    if "`verbose'" != "" {
+        display as text "PASS: assert_var_exists"
+    }
+    
     // Emit success marker
     noisily display "_STATATEST_PASS_:assert_var_exists_"
 

--- a/src/statatest/ado/assertions/assert_var_type.ado
+++ b/src/statatest/ado/assertions/assert_var_type.ado
@@ -1,8 +1,8 @@
-*! assert_var_type v1.0.0  statatest  2025-12-30
+*! assert_var_type v1.1.0  statatest  2025-12-30
 *! Assert that a variable has the expected type.
 *!
 *! Syntax:
-*!   assert_var_type varname, type(string) [message(string)]
+*!   assert_var_type varname, type(string) [message(string)] [Verbose]
 *!
 *! Type options: numeric, string, byte, int, long, float, double, str#
 *!
@@ -15,7 +15,7 @@
 program define assert_var_type, rclass
     version 16
     
-    syntax varname, Type(string) [Message(string)]
+    syntax varname, Type(string) [Message(string)] [Verbose]
     
     // Get actual type using extended macro function
     local actual_type : type `varlist'
@@ -43,17 +43,25 @@ program define assert_var_type, rclass
     }
     
     if `type_match' == 0 {
-        display as error "ASSERTION FAILED: assert_var_type"
-        display as error "  Variable: `varlist'"
-        display as error "  Expected type: `type'"
-        display as error "  Actual type:   `actual_type'"
-        if `"`message'"' != "" {
-            display as error "  Message:  `message'"
+        if "`verbose'" != "" {
+            display as error "ASSERTION FAILED: assert_var_type"
+            display as error "  Variable: `varlist'"
+            display as error "  Expected type: `type'"
+            display as error "  Actual type:   `actual_type'"
+            if `"`message'"' != "" {
+                display as error "  Message:  `message'"
+            }
+        }
+        else {
+            display as error "FAIL: assert_var_type: `varlist' is `actual_type' not `type'"
         }
         noisily display "_STATATEST_FAIL_:assert_var_type_:`varlist' is `actual_type' not `type'_END_"
         exit 9
     }
     
+    if "`verbose'" != "" {
+        display as text "PASS: assert_var_type"
+    }
     noisily display "_STATATEST_PASS_:assert_var_type_"
     
     return local passed "1"

--- a/src/statatest/ado/fixtures/fixture_balanced_panel.ado
+++ b/src/statatest/ado/fixtures/fixture_balanced_panel.ado
@@ -1,15 +1,16 @@
 *! fixture_balanced_panel.ado
-*! Version 1.0.0
+*! Version 1.1.0, 2025-12-30
 *! Creates a balanced panel dataset for testing
 *!
 *! Syntax:
-*!   fixture_balanced_panel [, n_units(#) n_periods(#) start_year(#) seed(#)]
+*!   fixture_balanced_panel [, n_units(#) n_periods(#) start_year(#) seed(#) Verbose]
 *!
 *! Options:
 *!   n_units(#)     - Number of panel units (default: 10)
 *!   n_periods(#)   - Number of time periods (default: 5)
 *!   start_year(#)  - Starting year (default: 2015)
 *!   seed(#)        - Random seed for reproducibility (default: 12345)
+*!   Verbose        - Display fixture creation details
 *!
 *! Creates variables:
 *!   id    - Numeric panel unit identifier (1 to n_units)
@@ -22,7 +23,12 @@ program define fixture_balanced_panel
     version 16
     
     syntax [, n_units(integer 10) n_periods(integer 5) ///
-              start_year(integer 2015) seed(integer 12345)]
+              start_year(integer 2015) seed(integer 12345) Verbose]
+    
+    // Display creation message if verbose
+    if "`verbose'" != "" {
+        display as text "Creating balanced panel: n_units=`n_units', n_periods=`n_periods', start_year=`start_year'"
+    }
     
     // Clear existing data
     clear
@@ -59,6 +65,11 @@ program define fixture_balanced_panel
     return scalar n_obs = `n_obs'
     return scalar start_year = `start_year'
     return scalar end_year = `start_year' + `n_periods' - 1
+    
+    // Display completion message if verbose
+    if "`verbose'" != "" {
+        display as text "Fixture created: balanced_panel"
+    }
 end
 
 // Alias for economic naming

--- a/src/statatest/ado/fixtures/fixture_bipartite_network.ado
+++ b/src/statatest/ado/fixtures/fixture_bipartite_network.ado
@@ -1,11 +1,11 @@
 *! fixture_bipartite_network.ado
-*! Version 1.0.0
+*! Version 1.1.0, 2025-12-30
 *! Creates a bipartite network (two distinct node types) for testing
 *! Default structure: employer-employee (AKM-style)
 *!
 *! Syntax:
 *!   fixture_bipartite_network [, n_workers(#) n_firms(#) n_periods(#) ///
-*!                                 start_year(#) mobility(#) seed(#)]
+*!                                 start_year(#) mobility(#) seed(#) Verbose]
 *!
 *! Options:
 *!   n_workers(#)  - Number of workers (default: 500)
@@ -14,6 +14,7 @@
 *!   start_year(#) - Starting year (default: 2015)
 *!   mobility(#)   - Job mobility rate 0-1 (default: 0.15)
 *!   seed(#)       - Random seed (default: 12345)
+*!   Verbose       - Display fixture creation details
 *!
 *! Creates variables:
 *!   worker_id - Worker identifier (1 to n_workers)
@@ -31,7 +32,12 @@ program define fixture_bipartite_network
     version 16
     
     syntax [, n_workers(integer 500) n_firms(integer 50) n_periods(integer 5) ///
-              start_year(integer 2015) mobility(real 0.15) seed(integer 12345)]
+              start_year(integer 2015) mobility(real 0.15) seed(integer 12345) Verbose]
+    
+    // Display creation message if verbose
+    if "`verbose'" != "" {
+        display as text "Creating bipartite network: n_workers=`n_workers', n_firms=`n_firms', n_periods=`n_periods', mobility=`mobility'"
+    }
     
     clear
     set seed `seed'
@@ -111,6 +117,11 @@ program define fixture_bipartite_network
     return scalar n_firms = `n_firms'
     return scalar n_periods = `n_periods'
     return scalar mobility = `mobility'
+    
+    // Display completion message if verbose
+    if "`verbose'" != "" {
+        display as text "Fixture created: bipartite_network"
+    }
 end
 
 // Alias for employer-employee data

--- a/src/statatest/ado/fixtures/fixture_directed_network.ado
+++ b/src/statatest/ado/fixtures/fixture_directed_network.ado
@@ -1,15 +1,16 @@
 *! fixture_directed_network.ado
-*! Version 1.0.0
+*! Version 1.1.0, 2025-12-30
 *! Creates a sparse directed weighted network for testing
 *!
 *! Syntax:
-*!   fixture_directed_network [, n_firms(#) n_edges(#) temporal seed(#)]
+*!   fixture_directed_network [, n_firms(#) n_edges(#) temporal seed(#) Verbose]
 *!
 *! Options:
 *!   n_firms(#)  - Total number of firms (default: 100)
 *!   n_edges(#)  - Number of edges/transactions (default: 500)
 *!   temporal    - Add year dimension (2015-2019)
 *!   seed(#)     - Random seed (default: 12345)
+*!   Verbose     - Display fixture creation details
 *!
 *! Creates variables:
 *!   seller  - Seller firm ID (source node)
@@ -27,7 +28,13 @@
 program define fixture_directed_network
     version 16
     
-    syntax [, n_firms(integer 100) n_edges(integer 500) temporal seed(integer 12345)]
+    syntax [, n_firms(integer 100) n_edges(integer 500) temporal seed(integer 12345) Verbose]
+    
+    // Display creation message if verbose
+    if "`verbose'" != "" {
+        local temp_msg = cond("`temporal'" != "", "temporal", "cross-sectional")
+        display as text "Creating directed network: n_firms=`n_firms', n_edges=`n_edges', type=`temp_msg'"
+    }
     
     clear
     set seed `seed'
@@ -96,7 +103,11 @@ program define fixture_directed_network
     return scalar n_firms = `n_firms'
     return scalar n_sellers = `n_sellers'
     return scalar n_buyers = `n_buyers'
+    
+    // Display completion message if verbose
+    if "`verbose'" != "" {
+        display as text "Fixture created: directed_network"
+    }
 end
-
 </antml9:parameter>
 

--- a/src/statatest/ado/fixtures/fixture_empty_dataset.ado
+++ b/src/statatest/ado/fixtures/fixture_empty_dataset.ado
@@ -1,10 +1,10 @@
-*! fixture_empty_dataset v1.0.0  statatest  2025-12-26
+*! fixture_empty_dataset v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Built-in fixture: Creates an empty dataset with specified observations.
 *!
 *! Syntax:
-*!   fixture_empty_dataset [, scope(string) obs(integer)]
+*!   fixture_empty_dataset [, scope(string) obs(integer) Verbose]
 *!
 *! Example:
 *!   use_fixture empty_dataset
@@ -16,7 +16,12 @@
 program define fixture_empty_dataset, rclass
     version 16
 
-    syntax [, Scope(string) OBS(integer 0)]
+    syntax [, Scope(string) OBS(integer 0) Verbose]
+
+    // Display creation message if verbose
+    if "`verbose'" != "" {
+        display as text "Creating empty dataset: obs=`obs'"
+    }
 
     // Clear current data
     clear
@@ -24,6 +29,11 @@ program define fixture_empty_dataset, rclass
     // Set observations if specified
     if `obs' > 0 {
         quietly set obs `obs'
+    }
+
+    // Display completion message if verbose
+    if "`verbose'" != "" {
+        display as text "Fixture created: empty_dataset"
     }
 
     return local obs "`obs'"

--- a/src/statatest/ado/fixtures/fixture_multilevel_panel.ado
+++ b/src/statatest/ado/fixtures/fixture_multilevel_panel.ado
@@ -1,10 +1,10 @@
 *! fixture_multilevel_panel.ado
-*! Version 1.0.0
+*! Version 1.1.0, 2025-12-30
 *! Creates a multilevel/hierarchical panel dataset for testing
 *!
 *! Syntax:
 *!   fixture_multilevel_panel [, n_groups(#) n_units(#) n_periods(#) ///
-*!                               start_year(#) seed(#)]
+*!                               start_year(#) seed(#) Verbose]
 *!
 *! Options:
 *!   n_groups(#)   - Number of top-level groups (default: 5)
@@ -12,6 +12,7 @@
 *!   n_periods(#)  - Number of time periods (default: 5)
 *!   start_year(#) - Starting year (default: 2015)
 *!   seed(#)       - Random seed (default: 12345)
+*!   Verbose       - Display fixture creation details
 *!
 *! Creates variables:
 *!   group_id  - Top-level group identifier (e.g., country, industry)
@@ -28,7 +29,12 @@ program define fixture_multilevel_panel
     version 16
     
     syntax [, n_groups(integer 5) n_units(integer 10) n_periods(integer 5) ///
-              start_year(integer 2015) seed(integer 12345)]
+              start_year(integer 2015) seed(integer 12345) Verbose]
+    
+    // Display creation message if verbose
+    if "`verbose'" != "" {
+        display as text "Creating multilevel panel: n_groups=`n_groups', n_units=`n_units', n_periods=`n_periods'"
+    }
     
     clear
     set seed `seed'
@@ -83,6 +89,11 @@ program define fixture_multilevel_panel
     return scalar n_units = `n_units'
     return scalar n_periods = `n_periods'
     return scalar n_obs = `n_obs'
+    
+    // Display completion message if verbose
+    if "`verbose'" != "" {
+        display as text "Fixture created: multilevel_panel"
+    }
 end
 
 // Aliases for common multilevel structures

--- a/src/statatest/ado/fixtures/fixture_seed.ado
+++ b/src/statatest/ado/fixtures/fixture_seed.ado
@@ -1,10 +1,10 @@
-*! fixture_seed v1.0.0  statatest  2025-12-26
+*! fixture_seed v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Built-in fixture: Sets a reproducible random seed.
 *!
 *! Syntax:
-*!   fixture_seed [, scope(string) seed(integer)]
+*!   fixture_seed [, scope(string) seed(integer) Verbose]
 *!
 *! Example:
 *!   use_fixture seed
@@ -16,7 +16,12 @@
 program define fixture_seed, rclass
     version 16
 
-    syntax [, Scope(string) SEED(integer 12345)]
+    syntax [, Scope(string) SEED(integer 12345) Verbose]
+
+    // Display creation message if verbose
+    if "`verbose'" != "" {
+        display as text "Setting random seed: seed=`seed'"
+    }
 
     // Store original seed state for restoration
     local original_seed = c(rngstate)
@@ -24,6 +29,11 @@ program define fixture_seed, rclass
 
     // Set reproducible seed
     set seed `seed'
+
+    // Display completion message if verbose
+    if "`verbose'" != "" {
+        display as text "Fixture created: seed"
+    }
 
     return local seed "`seed'"
 end

--- a/src/statatest/ado/fixtures/fixture_tempfile.ado
+++ b/src/statatest/ado/fixtures/fixture_tempfile.ado
@@ -1,4 +1,4 @@
-*! fixture_tempfile v1.0.0  statatest  2025-12-26
+*! fixture_tempfile v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Built-in fixture: Creates a temporary file path.
@@ -8,7 +8,7 @@
 *! after the test.
 *!
 *! Syntax:
-*!   fixture_tempfile [, scope(string) suffix(string)]
+*!   fixture_tempfile [, scope(string) suffix(string) Verbose]
 *!
 *! Example:
 *!   use_fixture tempfile
@@ -17,11 +17,16 @@
 program define fixture_tempfile, rclass
     version 16
 
-    syntax [, Scope(string) SUFfix(string)]
+    syntax [, Scope(string) SUFfix(string) Verbose]
 
     // Default suffix is .dta
     if `"`suffix'"' == "" {
         local suffix ".dta"
+    }
+
+    // Display creation message if verbose
+    if "`verbose'" != "" {
+        display as text "Creating temporary file path: suffix=`suffix'"
     }
 
     // Generate temporary file path
@@ -33,6 +38,11 @@ program define fixture_tempfile, rclass
 
     // Store for cleanup tracking
     global _FIXTURE_tempfile_cleanup "`filepath'"
+
+    // Display completion message if verbose
+    if "`verbose'" != "" {
+        display as text "Fixture created: tempfile"
+    }
 
     return local path "`filepath'"
 end

--- a/src/statatest/ado/fixtures/fixture_unbalanced_panel.ado
+++ b/src/statatest/ado/fixtures/fixture_unbalanced_panel.ado
@@ -1,10 +1,10 @@
 *! fixture_unbalanced_panel.ado
-*! Version 1.0.0
+*! Version 1.1.0, 2025-12-30
 *! Creates an unbalanced panel dataset with gaps for testing
 *!
 *! Syntax:
 *!   fixture_unbalanced_panel [, n_units(#) n_periods(#) start_year(#) ///
-*!                               attrition(#) entry(#) seed(#)]
+*!                               attrition(#) entry(#) seed(#) Verbose]
 *!
 *! Options:
 *!   n_units(#)    - Number of panel units (default: 20)
@@ -13,6 +13,7 @@
 *!   attrition(#)  - Annual attrition rate 0-1 (default: 0.1)
 *!   entry(#)      - Annual entry rate 0-1 (default: 0.05)
 *!   seed(#)       - Random seed (default: 12345)
+*!   Verbose       - Display fixture creation details
 *!
 *! Creates variables:
 *!   id    - Panel unit identifier
@@ -28,7 +29,12 @@ program define fixture_unbalanced_panel
     version 16
     
     syntax [, n_units(integer 20) n_periods(integer 10) start_year(integer 2010) ///
-              attrition(real 0.1) entry(real 0.05) seed(integer 12345)]
+              attrition(real 0.1) entry(real 0.05) seed(integer 12345) Verbose]
+    
+    // Display creation message if verbose
+    if "`verbose'" != "" {
+        display as text "Creating unbalanced panel: n_units=`n_units', n_periods=`n_periods', attrition=`attrition', entry=`entry'"
+    }
     
     clear
     set seed `seed'
@@ -97,6 +103,11 @@ program define fixture_unbalanced_panel
     quietly distinct id
     return scalar n_units = r(ndistinct)
     return scalar n_periods = `n_periods'
+    
+    // Display completion message if verbose
+    if "`verbose'" != "" {
+        display as text "Fixture created: unbalanced_panel"
+    }
 end
 
 // Alias

--- a/src/statatest/ado/fixtures/use_fixture.ado
+++ b/src/statatest/ado/fixtures/use_fixture.ado
@@ -1,10 +1,10 @@
-*! use_fixture v1.0.0  statatest  2025-12-26
+*! use_fixture v1.1.0  statatest  2025-12-30
 *! Author: Jose Ignacio Gonzalez Rojas
 *!
 *! Request a fixture by name, invoking setup if needed.
 *!
 *! Syntax:
-*!   use_fixture name [, scope(string)]
+*!   use_fixture name [, scope(string) Verbose]
 *!
 *! Scopes:
 *!   - function (default): Setup/teardown per test function
@@ -18,7 +18,7 @@
 program define use_fixture, rclass
     version 16
 
-    syntax anything(name=fixture_name), [Scope(string)]
+    syntax anything(name=fixture_name), [Scope(string) Verbose]
 
     // Default scope is function
     if `"`scope'"' == "" {
@@ -52,8 +52,13 @@ program define use_fixture, rclass
         exit 111
     }
 
-    // Run fixture setup
-    `setup_prog', scope(`scope')
+    // Run fixture setup (pass verbose if specified)
+    if "`verbose'" != "" {
+        `setup_prog', scope(`scope') verbose
+    }
+    else {
+        `setup_prog', scope(`scope')
+    }
 
     // Mark fixture as active
     scalar `fixture_var' = 1


### PR DESCRIPTION
## Summary

Add `verbose` option to all 29 ado files, restructuring output for better user control.

### Behavior

| Mode | Failure Output | Success Output |
|------|----------------|----------------|
| **Default** | Concise one-liner: `FAIL: assert_equal: 5 != 10` | Silent (marker only) |
| **Verbose** | Detailed multi-line with context | `PASS: assert_equal` |

### Assertions (20 files)

```stata
// Default - minimal output
assert_equal `x', expected(5)
// On failure: FAIL: assert_equal: 3 != 5

// Verbose - detailed output  
assert_equal `x', expected(5) verbose
// On failure:
//   ASSERTION FAILED: assert_equal
//     Expected: 5
//     Actual: 3
```

### Fixtures (9 files)

```stata
// Default - silent
fixture_seed, seed(42)

// Verbose - shows progress
fixture_seed, seed(42) verbose
// Output:
//   Setting random seed: seed=42
//   Fixture created: seed
```

### Files Changed

**Assertions**: assert_approx_equal, assert_count, assert_equal, assert_error, assert_false, assert_file_exists, assert_identity, assert_in_range, assert_label_exists, assert_no_missing, assert_noerror, assert_obs_count, assert_panel_structure, assert_positive, assert_sorted, assert_sum_equals, assert_true, assert_unique, assert_var_exists, assert_var_type

**Fixtures**: fixture_balanced_panel, fixture_bipartite_network, fixture_directed_network, fixture_empty_dataset, fixture_multilevel_panel, fixture_seed, fixture_tempfile, fixture_unbalanced_panel, use_fixture

## Test Plan

- [x] All 89 Python tests pass
- [ ] Manual Stata testing for verbose output

Closes #36